### PR TITLE
Fix regenerate arcanist cert, setup stuff and avoid accept non valid image files as profile picture.

### DIFF
--- a/src/applications/people/controller/profileedit/__init__.php
+++ b/src/applications/people/controller/profileedit/__init__.php
@@ -15,6 +15,7 @@ phutil_require_module('phabricator', 'view/form/control/file');
 phutil_require_module('phabricator', 'view/form/control/submit');
 phutil_require_module('phabricator', 'view/form/control/text');
 phutil_require_module('phabricator', 'view/form/control/textarea');
+phutil_require_module('phabricator', 'view/form/error');
 phutil_require_module('phabricator', 'view/layout/panel');
 
 phutil_require_module('phutil', 'utils');

--- a/src/applications/people/controller/settings/PhabricatorUserSettingsController.php
+++ b/src/applications/people/controller/settings/PhabricatorUserSettingsController.php
@@ -118,14 +118,22 @@ class PhabricatorUserSettingsController extends PhabricatorPeopleController {
             $err = idx($_FILES['profile'], 'error');
             if ($err != UPLOAD_ERR_NO_FILE) {
               $file = PhabricatorFile::newFromPHPUpload($_FILES['profile']);
-              $user->setProfileImagePHID($file->getPHID());
+              $okay = $file->isTransformableImage();
+
+              if ($okay) {
+                 $user->setProfileImagePHID($file->getPHID());
+              } else {
+                $errors[] =
+                  'Only valid image files (jpg, jpeg, png or gif) '.
+                  'will be accepted.';
+              }
             }
           }
 
           $user->setRealName($request->getStr('realname'));
 
           if (!strlen($user->getRealName())) {
-            $errors[] = 'Real name must be nonempty';
+            $errors[] = 'Real name must be nonempty.';
             $e_realname = 'Required';
           }
 
@@ -245,7 +253,6 @@ class PhabricatorUserSettingsController extends PhabricatorPeopleController {
     $regen_form = new AphrontFormView();
     $regen_form
       ->setUser($user)
-      ->setWorkflow(true)
       ->setAction('/settings/page/arcanist/')
       ->appendChild(
         '<p class="aphront-form-instructions">You can regenerate this '.
@@ -526,7 +533,5 @@ class PhabricatorUserSettingsController extends PhabricatorPeopleController {
 
     return $notice.$panel->render();
 
-
   }
-
 }

--- a/src/infrastructure/setup/PhabricatorSetup.php
+++ b/src/infrastructure/setup/PhabricatorSetup.php
@@ -130,18 +130,28 @@ class PhabricatorSetup {
         self::writeDoc('article/Configuration_Guide.html');
       return;
     } else {
-      self::write(" okay  Custom configuration loaded.\n");
-    }
-
-    if (!PhabricatorEnv::getEnvConfig('phabricator.base-uri')) {
-      self::writeFailure();
-      self::write(
-        "Setup failure! You must specify 'phabricator.base-uri' in your ".
-        "custom config file. Refer to 'default.conf.php' for documentation ".
-        "on configuration options.\n");
-      return;
-    } else {
-      self::write(" okay  phabricator.base-uri\n");
+      $host = PhabricatorEnv::getEnvConfig('phabricator.base-uri');
+      $protocol = id(new PhutilURI($host))->getProtocol();
+      if (!($protocol === 'http') || !($protocol === 'https')) {
+        self::writeFailure();
+        self::write(
+          "You must specify the protocol over which your host works (e.g.: ".
+          "\"http:// or https://\")\nin your custom config file.\nRefer to ".
+          "'default.conf.php' for documentation on configuration options.\n");
+        return;
+      }
+      if (preg_match('/.*\/$/', $host)) {
+        self::write(" okay  phabricator.base-uri\n");
+      } else {
+        self::writeFailure();
+        self::write(
+          "You must add a trailing slash at the end of the host\n(e.g.: ".
+          "\"http://phabricator.example.com/ instead of ".
+          "http://phabricator.example.com\")\nin your custom config file.".
+          "\nRefer to 'default.conf.php' for documentation on configuration ".
+          "options.\n");
+        return;
+      }
     }
 
     self::write("[OKAY] Basic configuration OKAY\n");

--- a/src/infrastructure/setup/__init__.php
+++ b/src/infrastructure/setup/__init__.php
@@ -4,8 +4,6 @@
  * @generated
  */
 
-
-
 phutil_require_module('phabricator', 'infrastructure/env');
 phutil_require_module('phabricator', 'infrastructure/setup/sql');
 phutil_require_module('phabricator', 'storage/connection/mysql');
@@ -14,7 +12,7 @@ phutil_require_module('phabricator', 'storage/queryfx');
 phutil_require_module('phutil', 'filesystem');
 phutil_require_module('phutil', 'future/exec');
 phutil_require_module('phutil', 'moduleutils');
+phutil_require_module('phutil', 'parser/uri');
 phutil_require_module('phutil', 'utils');
-
 
 phutil_require_source('PhabricatorSetup.php');


### PR DESCRIPTION
Fix regenerate arcanist cert, setup stuff and avoid accept non valid image files as profile picture.

Summary:
Well, since I couldn't regenerate my arcanist cert I figured out that this wass because "workflows" are unavailable there now. I really can not figure out why but it was.
I added in the setup script, the ability to check if is present the protocol of the host and if it has a trailing slash a the end of the line, since both are needed to generate the cert.

Users now only be able to upload valid image files with mimetype of jpg, jpeg, png and gif.

Test Plan:
FIRST: DO NOT apply those changes! then
1- go to settings->arcanist certificate and the click on regenerate ... humm
2- On your config file, delete the trailing slash at the end and the protocol on "phabricator.base-uri", then go to setting ->arcanist certificate. Here you will see something like this "phabricator.example.comapi\/" instead of "http:\/\/phabricator.example.com\/api\/".

SECOND: Now apply this changes:
1- Go to settings->arcanist certificate and the click on regenerate.
2- On your config file, delete the trailing slash at the end and the protocol on "phabricator.base-uri", and setup "phabricator.setup" to true.
3- Then go to setting->arcanist certificate and you could see that this was successfully generated.

THIRD:
Go to settings->account and try to upload an invalid image file, and do the same on "youruserna"->edit profile.

Reviewed By: epriestley
Reviewers: epriestley jungejason
CC: epriestley jugesason cadamo aran
Differential Revision: 391
