### PR TITLE
Pastebin mimetypes

### DIFF
--- a/src/applications/paste/controller/create/PhabricatorPasteCreateController.php
+++ b/src/applications/paste/controller/create/PhabricatorPasteCreateController.php
@@ -46,6 +46,7 @@ class PhabricatorPasteCreateController extends PhabricatorPasteController {
           $text,
           array(
             'name' => $title,
+            'mime-type' => 'text/plain; charset=utf-8',
         ));
         $paste->setFilePHID($paste_file->getPHID());
         $paste->setAuthorPHID($user->getPHID());


### PR DESCRIPTION
Summary:
PhabricatorFile() was setting the mimetype based on extension, meaning that you couldn't view the plain-text file if you saved a file, for example, as a .php. It would set the mimetype to "text/x-php; charset=us-ascii". In this commit, I force the mimetype to text/plain.

Test Plan:
Tried pasting a new file and was able to both see it via the pastebin viewer and in plain-text via File.

Reviewers:
epriestley

CC:

Differential Revision: 429
