### PR TITLE
IRC nick regex.

### DIFF
--- a/src/infrastructure/daemon/irc/bot/PhabricatorIRCBot.php
+++ b/src/infrastructure/daemon/irc/bot/PhabricatorIRCBot.php
@@ -56,9 +56,9 @@ final class PhabricatorIRCBot extends PhabricatorDaemon {
 
     $nick     = idx($config, 'nick', 'phabot');
 
-    if (!preg_match('/^[A-Za-z0-9_]+$/', $nick)) {
+    if (!preg_match('/^[A-Za-z0-9_`[{}^|\]\\-]+$/', $nick)) {
       throw new Exception(
-        "Nickname '{$nick}' is invalid, must be alphanumeric!");
+        "Nickname '{$nick}' is invalid!");
     }
 
     if (!$join) {


### PR DESCRIPTION
Summary:
Nicks can contain more characters than were allowed. The new regex is ugly,
but should include most of them.

Test Plan:
Joined the bot as phabot-c0d`eb1^ock successfully.

Reviewers:
epriestley

CC:

Differential Revision: 453
