### PR TITLE
D612

### DIFF
--- a/resources/sql/patches/055.add_author_to_files.sql
+++ b/resources/sql/patches/055.add_author_to_files.sql
@@ -1,0 +1,3 @@
+ALTER TABLE phabricator_file.file
+  ADD COLUMN authorPHID VARCHAR(64) BINARY,
+  ADD KEY (authorPHID);

--- a/src/applications/auth/controller/oauthregistration/default/PhabricatorOAuthDefaultRegistrationController.php
+++ b/src/applications/auth/controller/oauthregistration/default/PhabricatorOAuthDefaultRegistrationController.php
@@ -76,7 +76,8 @@ class PhabricatorOAuthDefaultRegistrationController
           $file = PhabricatorFile::newFromFileData(
             $image,
             array(
-              'name' => $provider->getProviderKey().'-profile.jpg'
+              'name' => $provider->getProviderKey().'-profile.jpg',
+              'authorPHID' => $user->getPHID(),
             ));
           $user->setProfileImagePHID($file->getPHID());
         }

--- a/src/applications/conduit/method/file/upload/ConduitAPI_file_upload_Method.php
+++ b/src/applications/conduit/method/file/upload/ConduitAPI_file_upload_Method.php
@@ -45,11 +45,13 @@ class ConduitAPI_file_upload_Method extends ConduitAPIMethod {
     $data = $request->getValue('data_base64');
     $name = $request->getValue('name');
     $data = base64_decode($data, $strict = true);
+    $user = $request->getUser();
 
     $file = PhabricatorFile::newFromFileData(
       $data,
       array(
-        'name' => $name
+        'name' => $name,
+        'authorPHID' => $user->getPHID(),
       ));
     return $file->getPHID();
   }

--- a/src/applications/files/controller/dropupload/PhabricatorFileDropUploadController.php
+++ b/src/applications/files/controller/dropupload/PhabricatorFileDropUploadController.php
@@ -20,6 +20,7 @@ class PhabricatorFileDropUploadController extends PhabricatorFileController {
 
   public function processRequest() {
     $request = $this->getRequest();
+    $user = $request->getUser();
 
     $data = file_get_contents('php://input');
     $name = $request->getStr('name');
@@ -28,6 +29,7 @@ class PhabricatorFileDropUploadController extends PhabricatorFileController {
       $data,
       array(
         'name' => $request->getStr('name'),
+        'authorPHID' => $user->getPHID(),
       ));
 
     $view = new AphrontAttachedFileView();

--- a/src/applications/files/controller/list/__init__.php
+++ b/src/applications/files/controller/list/__init__.php
@@ -6,8 +6,10 @@
 
 
 
+phutil_require_module('phabricator', 'aphront/response/404');
 phutil_require_module('phabricator', 'applications/files/controller/base');
 phutil_require_module('phabricator', 'applications/files/storage/file');
+phutil_require_module('phabricator', 'applications/people/storage/user');
 phutil_require_module('phabricator', 'view/control/pager');
 phutil_require_module('phabricator', 'view/control/table');
 phutil_require_module('phabricator', 'view/layout/panel');

--- a/src/applications/files/controller/macroedit/PhabricatorFileMacroEditController.php
+++ b/src/applications/files/controller/macroedit/PhabricatorFileMacroEditController.php
@@ -39,6 +39,7 @@ class PhabricatorFileMacroEditController extends PhabricatorFileController {
     $e_name = true;
 
     $request = $this->getRequest();
+    $user = $request->getUser();
     if ($request->isFormPost()) {
 
       $macro->setName($request->getStr('name'));
@@ -60,6 +61,7 @@ class PhabricatorFileMacroEditController extends PhabricatorFileController {
           idx($_FILES, 'file'),
           array(
             'name' => $request->getStr('name'),
+            'authorPHID' => $user->getPHID(),
           ));
         $macro->setFilePHID($file->getPHID());
 

--- a/src/applications/files/controller/upload/__init__.php
+++ b/src/applications/files/controller/upload/__init__.php
@@ -8,11 +8,10 @@
 
 phutil_require_module('phabricator', 'aphront/response/redirect');
 phutil_require_module('phabricator', 'applications/files/controller/base');
-phutil_require_module('phabricator', 'applications/files/storage/file');
+phutil_require_module('phabricator', 'infrastructure/celerity/api');
 phutil_require_module('phabricator', 'view/form/base');
-phutil_require_module('phabricator', 'view/form/control/file');
+phutil_require_module('phabricator', 'view/form/control/draganddropupload');
 phutil_require_module('phabricator', 'view/form/control/submit');
-phutil_require_module('phabricator', 'view/form/control/text');
 phutil_require_module('phabricator', 'view/layout/panel');
 
 phutil_require_module('phutil', 'markup');

--- a/src/applications/files/controller/view/PhabricatorFileViewController.php
+++ b/src/applications/files/controller/view/PhabricatorFileViewController.php
@@ -71,6 +71,20 @@ class PhabricatorFileViewController extends PhabricatorFileController {
         break;
     }
 
+    $author_child = null;
+    if ($file->getAuthorPHID()) {
+      $author = id(new PhabricatorUser())->loadOneWhere(
+        'phid = %s',
+        $file->getAuthorPHID());
+
+      if ($author) {
+        $author_child = id(new AphrontFormStaticControl())
+          ->setLabel('Author')
+          ->setName('author')
+          ->setValue($author->getUserName());
+      }
+    }
+
     $form = new AphrontFormView();
 
     if ($file->isViewableInBrowser()) {
@@ -80,7 +94,7 @@ class PhabricatorFileViewController extends PhabricatorFileController {
       $form->setAction('/file/download/'.$file->getPHID().'/');
       $button_name = 'Download File';
     }
-    $form->setUser($this->getRequest()->getUser());
+    $form->setUser($user);
     $form
       ->appendChild(
         id(new AphrontFormStaticControl())
@@ -92,6 +106,7 @@ class PhabricatorFileViewController extends PhabricatorFileController {
           ->setLabel('PHID')
           ->setName('phid')
           ->setValue($file->getPHID()))
+      ->appendChild($author_child)
       ->appendChild(
         id(new AphrontFormStaticControl())
           ->setLabel('Created')

--- a/src/applications/files/controller/view/__init__.php
+++ b/src/applications/files/controller/view/__init__.php
@@ -13,6 +13,7 @@ phutil_require_module('phabricator', 'applications/files/controller/base');
 phutil_require_module('phabricator', 'applications/files/storage/file');
 phutil_require_module('phabricator', 'applications/files/storage/transformed');
 phutil_require_module('phabricator', 'applications/files/uri');
+phutil_require_module('phabricator', 'applications/people/storage/user');
 phutil_require_module('phabricator', 'view/control/table');
 phutil_require_module('phabricator', 'view/form/base');
 phutil_require_module('phabricator', 'view/form/control/static');

--- a/src/applications/files/storage/file/PhabricatorFile.php
+++ b/src/applications/files/storage/file/PhabricatorFile.php
@@ -29,6 +29,7 @@ class PhabricatorFile extends PhabricatorFileDAO {
   protected $name;
   protected $mimeType;
   protected $byteSize;
+  protected $authorPHID;
 
   protected $storageEngine;
   protected $storageFormat;
@@ -88,9 +89,14 @@ class PhabricatorFile extends PhabricatorFileDAO {
     $file_name = idx($params, 'name');
     $file_name = self::normalizeFileName($file_name);
 
+    // If for whatever reason, authorPHID isn't passed as a param
+    // (always the case with newFromFileDownload()), store a ''
+    $authorPHID = idx($params, 'authorPHID');
+
     $file = new PhabricatorFile();
     $file->setName($file_name);
     $file->setByteSize(strlen($data));
+    $file->setAuthorPHID($authorPHID);
 
     $blob = new PhabricatorFileStorageBlob();
     $blob->setData($data);

--- a/src/applications/maniphest/controller/transactionsave/ManiphestTransactionSaveController.php
+++ b/src/applications/maniphest/controller/transactionsave/ManiphestTransactionSaveController.php
@@ -53,7 +53,11 @@ class ManiphestTransactionSaveController extends ManiphestController {
       if (!empty($_FILES['file'])) {
         $err = idx($_FILES['file'], 'error');
         if ($err != UPLOAD_ERR_NO_FILE) {
-          $file = PhabricatorFile::newFromPHPUpload($_FILES['file']);
+          $file = PhabricatorFile::newFromPHPUpload(
+            $_FILES['file'],
+            array(
+              'authorPHID' => $user->getPHID(),
+            ));
           $files[] = $file;
         }
       }

--- a/src/applications/metamta/controller/sendgridreceive/PhabricatorMetaMTASendGridReceiveController.php
+++ b/src/applications/metamta/controller/sendgridreceive/PhabricatorMetaMTASendGridReceiveController.php
@@ -26,6 +26,7 @@ class PhabricatorMetaMTASendGridReceiveController
   public function processRequest() {
 
     $request = $this->getRequest();
+    $user = $request->getUser();
 
     $raw_headers = $request->getStr('headers');
     $raw_headers = explode("\n", rtrim($raw_headers));
@@ -51,7 +52,11 @@ class PhabricatorMetaMTASendGridReceiveController
     $file_phids = array();
     foreach ($_FILES as $file_raw) {
       try {
-        $file = PhabricatorFile::newFromPHPUpload($file_raw);
+        $file = PhabricatorFile::newFromPHPUpload(
+          $file_raw,
+          array(
+            'authorPHID' => $user->getPHID(),
+          ));
         $file_phids[] = $file->getPHID();
       } catch (Exception $ex) {
         phlog($ex);

--- a/src/applications/paste/controller/create/PhabricatorPasteCreateController.php
+++ b/src/applications/paste/controller/create/PhabricatorPasteCreateController.php
@@ -59,6 +59,7 @@ class PhabricatorPasteCreateController extends PhabricatorPasteController {
           array(
             'name' => $title,
             'mime-type' => 'text/plain; charset=utf-8',
+            'authorPHID' => $user->getPHID(),
         ));
         $paste->setFilePHID($paste_file->getPHID());
         $paste->setAuthorPHID($user->getPHID());

--- a/src/applications/people/controller/profileedit/PhabricatorPeopleProfileEditController.php
+++ b/src/applications/people/controller/profileedit/PhabricatorPeopleProfileEditController.php
@@ -40,7 +40,11 @@ class PhabricatorPeopleProfileEditController
       if (!empty($_FILES['image'])) {
         $err = idx($_FILES['image'], 'error');
         if ($err != UPLOAD_ERR_NO_FILE) {
-          $file = PhabricatorFile::newFromPHPUpload($_FILES['image']);
+          $file = PhabricatorFile::newFromPHPUpload(
+            $_FILES['image'],
+            array(
+              'authorPHID' => $user->getPHID(),
+            ));
           $okay = $file->isTransformableImage();
           if ($okay) {
             $xformer = new PhabricatorImageTransformer();

--- a/src/applications/people/controller/settings/PhabricatorUserSettingsController.php
+++ b/src/applications/people/controller/settings/PhabricatorUserSettingsController.php
@@ -117,7 +117,11 @@ class PhabricatorUserSettingsController extends PhabricatorPeopleController {
           if (!empty($_FILES['profile'])) {
             $err = idx($_FILES['profile'], 'error');
             if ($err != UPLOAD_ERR_NO_FILE) {
-              $file = PhabricatorFile::newFromPHPUpload($_FILES['profile']);
+              $file = PhabricatorFile::newFromPHPUpload(
+                $_FILES['profile'],
+                array(
+                  'authorPHID' => $user->getPHID(),
+                ));
               $okay = $file->isTransformableImage();
               if ($okay) {
                 $xformer = new PhabricatorImageTransformer();

--- a/src/applications/project/controller/profileedit/PhabricatorProjectProfileEditController.php
+++ b/src/applications/project/controller/profileedit/PhabricatorProjectProfileEditController.php
@@ -57,7 +57,11 @@ class PhabricatorProjectProfileEditController
       if (!empty($_FILES['image'])) {
         $err = idx($_FILES['image'], 'error');
         if ($err != UPLOAD_ERR_NO_FILE) {
-          $file = PhabricatorFile::newFromPHPUpload($_FILES['image']);
+          $file = PhabricatorFile::newFromPHPUpload(
+            $_FILES['image'],
+            array(
+              'authorPHID' => $user->getPHID(),
+            ));
           $okay = $file->isTransformableImage();
           if ($okay) {
             $xformer = new PhabricatorImageTransformer();


### PR DESCRIPTION
Summary:
- have files be uploaded by drag+drop instead of browse.
- Files are named by their uploaded filename, the user isn't given a chance to enter a file name. Is this bad?
- Store author PHID now with files
- Allow an ?author=<username> to limit the /files/ list by author.
- If one file is uploaded, the user is taken to its info page.
- If several are uploaded, they are taken to a list of their files.

Test Plan:
- Quickly tested everything and it still worked, I'd recommend some people try this out before it gets committed though. It's a rather huge revision.

Reviewers:
epriestley, Ttech

CC:

Differential Revision: 612
