### PR TITLE
D616

### DIFF
--- a/src/applications/conduit/method/paste/info/ConduitAPI_paste_info_Method.php
+++ b/src/applications/conduit/method/paste/info/ConduitAPI_paste_info_Method.php
@@ -55,6 +55,7 @@ class ConduitAPI_paste_info_Method extends ConduitAPIMethod {
       'filePHID'    => $paste->getFilePHID(),
       'title'       => $paste->getTitle(),
       'dateCreated' => $paste->getDateCreated(),
+      'language'    => $paste->getLanguage(),
       'uri'         => PhabricatorEnv::getProductionURI('/P'.$paste->getID()),
     );
 

--- a/src/infrastructure/daemon/irc/handler/objectname/PhabricatorIRCObjectNameHandler.php
+++ b/src/infrastructure/daemon/irc/handler/objectname/PhabricatorIRCObjectNameHandler.php
@@ -122,7 +122,12 @@ class PhabricatorIRCObjectNameHandler extends PhabricatorIRCHandler {
             // since we (ideally) want to keep the bot to Conduit calls...and
             // not call to Phabricator-specific stuff (like actually loading
             // the User object and fetching his/her username.)
-            $output[$paste['phid']] = 'P'.$paste['id'].': '.$paste['uri'].' - '.$paste['title'];
+            $output[$paste['phid']] = 'P'.$paste['id'].': '.$paste['uri'].' - '.
+              $paste['title'];
+
+            if ($paste['language']) {
+              $output[$paste['phid']] .= ' ('.$paste['language'].')';
+            }
           }
         }
 


### PR DESCRIPTION
Summary:
Now that we store language with pastes, we can include this in Conduit.

Test Plan:
Tried it on a paste with a blank language, and one with a specified language.
    16:14:50 @CodeBlock P1
    16:14:51 @codeblock-phabot P1: http://phabricator.local/P1 - test.php
    16:15:05 @CodeBlock P43
    16:15:06 @codeblock-phabot P43: http://phabricator.local/P43 - sadoijfoisaf (php)

Reviewers:
epriestley, Ttech

CC:

Differential Revision: 616
