### PR TITLE
T341 Add a 'description' field to Phriction for annotating edits

### DIFF
--- a/resources/sql/patches/066.phrictioncontent.sql
+++ b/resources/sql/patches/066.phrictioncontent.sql
@@ -1,0 +1,2 @@
+alter table phabricator_phriction.phriction_content
+  add description varchar(512);

--- a/src/applications/phriction/controller/diff/PhrictionDiffController.php
+++ b/src/applications/phriction/controller/diff/PhrictionDiffController.php
@@ -239,7 +239,7 @@ class PhrictionDiffController
         phabricator_time($c->getDateCreated(), $user),
         phutil_escape_html('Version '.$c->getVersion()),
         $handles[$c->getAuthorPHID()]->renderLink(),
-        '',
+        phutil_escape_html($c->getDescription()),
       );
     }
 

--- a/src/applications/phriction/controller/edit/PhrictionEditController.php
+++ b/src/applications/phriction/controller/edit/PhrictionEditController.php
@@ -96,10 +96,10 @@ class PhrictionEditController
           $is_new = true;
           $document->save();
         }
-
         $new_content = new PhrictionContent();
         $new_content->setSlug($document->getSlug());
         $new_content->setTitle($title);
+        $new_content->setDescription($request->getStr('description'));
         $new_content->setContent($request->getStr('content'));
 
         $new_content->setDocumentID($document->getID());
@@ -176,6 +176,12 @@ class PhrictionEditController
           ->setValue($content->getTitle())
           ->setError($e_title)
           ->setName('title'))
+      ->appendChild(
+        id(new AphrontFormTextControl())
+          ->setLabel('Description')
+          ->setValue($content->getDescription())
+          ->setError(null)
+          ->setName('description'))
       ->appendChild(
         id(new AphrontFormStaticControl())
           ->setLabel('URI')

--- a/src/applications/phriction/controller/history/PhrictionHistoryController.php
+++ b/src/applications/phriction/controller/history/PhrictionHistoryController.php
@@ -100,7 +100,7 @@ class PhrictionHistoryController
           ),
           'Version '.$version),
         $handles[$content->getAuthorPHID()]->renderLink(),
-        '',
+        phutil_escape_html($content->getDescription()),
         $vs_previous,
         $vs_head,
       );

--- a/src/applications/phriction/storage/content/PhrictionContent.php
+++ b/src/applications/phriction/storage/content/PhrictionContent.php
@@ -26,5 +26,6 @@ class PhrictionContent extends PhrictionDAO {
   protected $title;
   protected $slug;
   protected $content;
+  protected $description;
 
 }


### PR DESCRIPTION
Summary:
Add a new column to PhrictionContent called 'comment' or 'description' or
something
        Add an optional field to the Phriction document editing interface that
allows you to add a comment

Test Plan:
Run the sql patch to modify phriction_content table
           Create a new wiki page in Phriction
           Type in words in description field and save the page
           Visit this page and click "Edit Page" button
           The content in the desciption field is saved

Reviewed By: epriestley
Reviewers: epriestley, hsb, codeblock
Commenters: codeblock
CC: aran, codeblock, hwang, epriestley
Differential Revision: 709
