### PR TITLE
Modified create workflow to support rapid templated task creation, made T

### DIFF
--- a/src/applications/maniphest/controller/taskdetail/ManiphestTaskDetailController.php
+++ b/src/applications/maniphest/controller/taskdetail/ManiphestTaskDetailController.php
@@ -163,6 +163,19 @@ class ManiphestTaskDetailController extends ManiphestController {
         implode("\n", $table).
       '</table>';
 
+    $create_new_button = '';
+    if ($request->getStr('workflow') == 'create') {
+      $create_new_button =
+        '<div class="create-button-container">'.
+           phutil_render_tag(
+           'a',
+           array(
+             'href' => '/maniphest/task/create/?template='.$task->getID(),
+             'class' => 'green button',
+           ),
+           'Create New Task').
+        '</div>';
+    }
 
     $actions = array();
 
@@ -196,6 +209,7 @@ class ManiphestTaskDetailController extends ManiphestController {
       '<div class="maniphest-panel">'.
         $action_list->render().
         '<div class="maniphest-task-detail-core">'.
+          $create_new_button.
           '<h1>'.
             '<span class="aphront-headsup-object-name">'.
               phutil_escape_html('T'.$task->getID()).

--- a/webroot/rsrc/css/application/maniphest/task-detail.css
+++ b/webroot/rsrc/css/application/maniphest/task-detail.css
@@ -16,7 +16,6 @@
   margin-bottom: 8px;
 }
 
-
 .maniphest-task-properties {
   font-size: 12px;
   width:    100%;
@@ -41,4 +40,9 @@
 
 .maniphest-task-detail-core {
   margin-right: 265px;
+}
+
+.maniphest-task-detail-core .create-button-container {
+  float:right;
+  margin-top:-0.5em;
 }


### PR DESCRIPTION
Modified create workflow to support rapid templated task creation, made Task Edit repopulate user input array fields on error

Reviewers: epriestley
Test Plan: Create a new task in Maniphest, then click "Create Another Task Like This"

Differential Revision: 734
