### PR TITLE
D778

### DIFF
--- a/webroot/rsrc/css/application/differential/changeset-view.css
+++ b/webroot/rsrc/css/application/differential/changeset-view.css
@@ -61,24 +61,20 @@
 
 .differential-diff td.old {
   background:   #ffd0d0;
-  color:        #161111;
 }
 
 .differential-diff td.new {
   background:   #d0ffd0;
-  color:        #111611;
 }
 
 .differential-diff td.old-full,
 .differential-diff td.old span.bright {
   background: #ffaaaa;
-  color:      #221111;
 }
 
 .differential-diff td.new-full,
 .differential-diff td.new span.bright {
   background: #aaffaa;
-  color:      #112211;
 }
 
 .differential-diff td.show-more,


### PR DESCRIPTION
Stop overriding color in differential, when we highlight specific changes.

Summary:
When we highlight specific changes (use the '.bright' css class), we override syntax highlighting with 'color:'.
This commit makes us stop doing that, by removing the 'color:'.

Test Plan:
My local instance sucks, so I can't test this :P @epriestley? :P

Reviewers:
epriestley

CC:

Differential Revision: 778
