### PR TITLE
D837

### DIFF
--- a/src/applications/maniphest/controller/taskedit/ManiphestTaskEditController.php
+++ b/src/applications/maniphest/controller/taskedit/ManiphestTaskEditController.php
@@ -445,6 +445,8 @@ class ManiphestTaskEditController extends ManiphestController {
                     '<tt>'.phutil_escape_html($email_create).'</tt>';
     }
 
+    $panel_id = celerity_generate_unique_node_id();
+
     $form
       ->appendChild(
         id(new AphrontFormTextAreaControl())
@@ -453,6 +455,12 @@ class ManiphestTaskEditController extends ManiphestController {
           ->setCaption($email_hint)
           ->setValue($task->getDescription()))
       ->appendChild(
+        id(new AphrontFormDragAndDropUploadControl())
+          ->setLabel('Attached Files')
+          ->setName('files')
+          ->setDragAndDropTarget($panel_id)
+          ->setActivatedClass('aphront-panel-view-drag-and-drop'))
+      ->appendChild(
         id(new AphrontFormSubmitControl())
           ->addCancelButton($cancel_uri)
           ->setValue($button_name));
@@ -460,6 +468,7 @@ class ManiphestTaskEditController extends ManiphestController {
     $panel = new AphrontPanelView();
     $panel->setWidth(AphrontPanelView::WIDTH_FULL);
     $panel->setHeader($header_name);
+    $panel->setID($panel_id);
     $panel->appendChild($form);
 
     return $this->buildStandardPageResponse(

--- a/src/applications/maniphest/controller/taskedit/__init__.php
+++ b/src/applications/maniphest/controller/taskedit/__init__.php
@@ -24,6 +24,7 @@ phutil_require_module('phabricator', 'infrastructure/env');
 phutil_require_module('phabricator', 'infrastructure/javelin/api');
 phutil_require_module('phabricator', 'infrastructure/javelin/markup');
 phutil_require_module('phabricator', 'view/form/base');
+phutil_require_module('phabricator', 'view/form/control/draganddropupload');
 phutil_require_module('phabricator', 'view/form/control/markup');
 phutil_require_module('phabricator', 'view/form/control/select');
 phutil_require_module('phabricator', 'view/form/control/static');


### PR DESCRIPTION
Allow files to be attached to Maniphest tasks while the task is being created.

Summary:
This commit lets users who are filing Maniphest tasks to attache files to them
right off the bat.

Test Plan:
{F3545}

and

{F3546}

Reviewers: epriestley, fmoo, aran

CC:

Differential Revision: 837
