### PR TITLE
Support for single-reply-handler domain

### DIFF
--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -207,6 +207,16 @@ return array(
   // PhabricatorMailReplyHandler (and possibly of ManiphestReplyHandler).
   'metamta.maniphest.reply-handler' => 'ManiphestReplyHandler',
 
+  // If you don't want phabricator to take up an entire domain
+  // (or subdomain for that matter), you can use this and set a common
+  // prefix for mail sent by phabricator. It will make use of the fact that
+  // a mail-address such as phabricator+D123+1hjk213h@example.com will be
+  // delivered to the phabricator users mailbox.
+  // Set this to the left part of the email address and it well get
+  // prepended to all outgoing mail. If you want to use e.g.
+  // 'phabricator@example.com' this should be set to 'phabricator'.
+  'metamta.single-reply-handler-prefix' => null,
+
   // Prefix prepended to mail sent by Maniphest. You can change this to
   // distinguish between testing and development installs, for example.
   'metamta.maniphest.subject-prefix' => '[Maniphest]',

--- a/src/applications/metamta/replyhandler/base/PhabricatorMailReplyHandler.php
+++ b/src/applications/metamta/replyhandler/base/PhabricatorMailReplyHandler.php
@@ -166,7 +166,16 @@ abstract class PhabricatorMailReplyHandler {
       $receiver->getMailKey(),
       $receiver->getPHID());
 
-    return "{$prefix}{$receiver_id}+public+{$hash}@{$domain}";
+    $address = "{$prefix}{$receiver_id}+public+{$hash}@{$domain}";
+    return $this->getSingleReplyHandlerPrefix($address);
+  }
+
+  protected function getSingleReplyHandlerPrefix($address) {
+    $single_handle_prefix = PhabricatorEnv::getEnvConfig(
+      'metamta.single-reply-handler-prefix');
+    return ($single_handle_prefix)
+      ? $single_handle_prefix . '+' . $address
+      : $address;
   }
 
   protected function getDefaultPrivateReplyHandlerEmailAddress(
@@ -186,7 +195,8 @@ abstract class PhabricatorMailReplyHandler {
       $handle->getPHID());
     $domain = $this->getReplyHandlerDomain();
 
-    return "{$prefix}{$receiver_id}+{$user_id}+{$hash}@{$domain}";
+    $address = "{$prefix}{$receiver_id}+{$user_id}+{$hash}@{$domain}";
+    return $this->getSingleReplyHandlerPrefix($address);
   }
 
 }

--- a/src/applications/metamta/storage/receivedmail/PhabricatorMetaMTAReceivedMail.php
+++ b/src/applications/metamta/storage/receivedmail/PhabricatorMetaMTAReceivedMail.php
@@ -92,8 +92,16 @@ class PhabricatorMetaMTAReceivedMail extends PhabricatorMetaMTADAO {
     // We've already stripped this, so look for an object address which has
     // a format like: D291+291+b0a41ca848d66dcc@example.com
     $matches = null;
+    $single_handle_prefix = PhabricatorEnv::getEnvConfig(
+      'metamta.single-reply-handler-prefix');
+
+    $prefixPattern = ($single_handle_prefix)
+      ? preg_quote($single_handle_prefix, '/') . '\+'
+      : '';
+    $pattern = "/^{$prefixPattern}((?:D|T)\d+)\+([\w]+)\+([a-f0-9]{16})@/U";
+
     $ok = preg_match(
-      '/^((?:D|T)\d+)\+([\w]+)\+([a-f0-9]{16})@/U',
+      $pattern,
       $to,
       $matches);
 

--- a/src/docs/configuration/configuring_inbound_email.diviner
+++ b/src/docs/configuration/configuring_inbound_email.diviner
@@ -43,6 +43,14 @@ configured correctly, according to the instructions below -- will parse incoming
 email and allow users to interact with Maniphest tasks and Differential
 revisions over email.
 
+If you don't want phabricator to take up an entire domain (or subdomain) you
+can configure a general prefix so you can use a single mailbox to receive mail
+on. To make use of this set ##metamta.single-reply-handler-prefix## to the
+prefix of your choice, and phabricator will prepend this to the 'Reply-To'
+mail address. This works because everything up to the first (optional) '+'
+character in an email-address is considered the receiver, and everything
+after is essentially "ignored".
+
 You can also set up a task creation email address, like ##bugs@example.com##,
 which will create a Maniphest task out of any email which is set to it. To do
 this, set ##metamta.maniphest.public-create-email## in your configuration. This


### PR DESCRIPTION
Summary:
This allows you to configure a single mailbox for all mail sent by phabricator,
so you can keep a mailaddress like bugs@example.com and don't need a catchall on your
domain/subdomain.

Test Plan:
Enabled and disabled suffix. Saw mails generated have to correct prefix. Also
piped raw mails into the scripts/mail/mail_handler.php and ensured comments went into
phabricator for both maniphest
and differential.

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, epriestley

Differential Revision: 815
