### PR TITLE
Added the ability to support Irc Bots that need to login into private IRC

### DIFF
--- a/src/infrastructure/daemon/irc/bot/PhabricatorIRCBot.php
+++ b/src/infrastructure/daemon/irc/bot/PhabricatorIRCBot.php
@@ -53,7 +53,8 @@ final class PhabricatorIRCBot extends PhabricatorDaemon {
     $port     = idx($config, 'port', 6667);
     $join     = idx($config, 'join', array());
     $handlers = idx($config, 'handlers', array());
-
+    $user     = idx($config,  'user');
+    $pass     = idx($config,  'pass');
     $nick     = idx($config, 'nick', 'phabot');
 
     if (!preg_match('/^[A-Za-z0-9_`[{}^|\]\\-]+$/', $nick)) {
@@ -101,8 +102,15 @@ final class PhabricatorIRCBot extends PhabricatorDaemon {
     }
 
     $this->socket = $socket;
-
-    $this->writeCommand('USER', "{$nick} 0 * :{$nick}");
+    if (!$user){
+      $this->writeCommand('USER', "{$nick} 0 * :{$nick}");
+    }else{
+      $this->writeCommand('USER', "{$user} 0 * :{$user}");
+    }
+    if ($pass){
+      $this->writeCommand('PASS',"{$pass}");
+    }
+    
     $this->writeCommand('NICK', "{$nick}");
     foreach ($join as $channel) {
       $this->writeCommand('JOIN', "{$channel}");


### PR DESCRIPTION
Added the ability to support Irc Bots that need to login into private IRC Servers. Requires the following to be added to the config.json file

"user":"authenticationusername",
"pass":"thisuserspassowrd",

This will allow people with internal irc servers to use this if they control access from ldap for irc.
