### PR TITLE
Added the ability for SSL to be fined in the irc_config.json file, if not

### DIFF
--- a/src/infrastructure/daemon/irc/bot/PhabricatorIRCBot.php
+++ b/src/infrastructure/daemon/irc/bot/PhabricatorIRCBot.php
@@ -56,7 +56,8 @@ final class PhabricatorIRCBot extends PhabricatorDaemon {
     $pass     = idx($config, 'pass');
     $nick     = idx($config, 'nick', 'phabot');
     $user     = idx($config, 'user', $nick);
-
+    $ssl      = idx($config, 'ssl', false);
+    
     if (!preg_match('/^[A-Za-z0-9_`[{}^|\]\\-]+$/', $nick)) {
       throw new Exception(
         "Nickname '{$nick}' is invalid!");
@@ -92,7 +93,11 @@ final class PhabricatorIRCBot extends PhabricatorDaemon {
 
     $errno = null;
     $error = null;
-    $socket = fsockopen($server, $port, $errno, $error);
+    if (!$ssl){
+      $socket = fsockopen($server, $port, $errno, $error);
+    }else{
+      $socket = fsockopen('ssl://'.$server, $port, $errno, $error);
+    }
     if (!$socket) {
       throw new Exception("Failed to connect, #{$errno}: {$error}");
     }


### PR DESCRIPTION
Added the ability for SSL to be fined in the irc_config.json file, if not there we assume that its false and continue on our way. if "ssl":true is in the config then we are going to use ssl:// to make the connection use openssl.
