### PR TITLE
Irc Nick Password and SSL

### DIFF
--- a/src/infrastructure/daemon/irc/bot/PhabricatorIRCBot.php
+++ b/src/infrastructure/daemon/irc/bot/PhabricatorIRCBot.php
@@ -57,7 +57,8 @@ final class PhabricatorIRCBot extends PhabricatorDaemon {
     $nick     = idx($config, 'nick', 'phabot');
     $user     = idx($config, 'user', $nick);
     $ssl      = idx($config, 'ssl', false);
-    
+	$nickpass = idx($config, 'nickpass');
+
     if (!preg_match('/^[A-Za-z0-9_`[{}^|\]\\-]+$/', $nick)) {
       throw new Exception(
         "Nickname '{$nick}' is invalid!");
@@ -111,6 +112,10 @@ final class PhabricatorIRCBot extends PhabricatorDaemon {
     if ($pass) {
       $this->writeCommand('PASS', "{$pass}");
     }
+
+	if ($nickpass){
+		$this->writeCommand("NickServ IDENTIFY ", "{$nickpass}");
+	}
 
     $this->writeCommand('NICK', "{$nick}");
     foreach ($join as $channel) {


### PR DESCRIPTION
Added the ability for SSL socket support and nick for the bot to have a identify password. To use ssl just set "ssl":true in the ircbot_config.json file. To set a password for the irc bot just set "nickpass":"passwordhere" in you ircbot_config.json file.
