### PR TITLE
SVN error message may also be "File not found"

### DIFF
--- a/src/applications/repository/daemon/commitdiscovery/svn/PhabricatorRepositorySvnCommitDiscoveryDaemon.php
+++ b/src/applications/repository/daemon/commitdiscovery/svn/PhabricatorRepositorySvnCommitDiscoveryDaemon.php
@@ -64,7 +64,7 @@ class PhabricatorRepositorySvnCommitDiscoveryDaemon
         $uri,
         $upper_bound - 1);
       if ($err) {
-        if (preg_match('/path not found/', $stderr)) {
+        if (preg_match('/(path|File) not found/', $stderr)) {
           // We've gone all the way back through history and this path was not
           // affected by earlier commits.
           break;


### PR DESCRIPTION
Some repositories may have a troubled history, and PhabricatorRepositorySvnCommitDiscoveryDaemon.php fails with a "File not found" error as it traverses back looking for initial revision to import. It already check for "path not found" error, so this should probably be fixed with a simple change in that regular expression. It certainly worked in my case.
