### PR TITLE
Revision: D909

### DIFF
--- a/src/applications/diffusion/query/diff/svn/DiffusionSvnDiffQuery.php
+++ b/src/applications/diffusion/query/diff/svn/DiffusionSvnDiffQuery.php
@@ -140,9 +140,9 @@ final class DiffusionSvnDiffQuery extends DiffusionDiffQuery {
     $repository = $drequest->getRepository();
 
     list($ref, $rev) = $spec;
-    return new ExecFuture(
-      'svn --non-interactive cat %s%s@%d',
-      $repository->getDetail('remote-uri'),
+    return $repository->getRemoteCommandFuture(
+      'cat %s%s@%d',
+      $repository->getRemoteURI(),
       $ref,
       $rev);
   }

--- a/src/applications/diffusion/query/diff/svn/__init__.php
+++ b/src/applications/diffusion/query/diff/svn/__init__.php
@@ -16,7 +16,6 @@ phutil_require_module('phabricator', 'applications/diffusion/query/pathchange/ba
 phutil_require_module('phabricator', 'infrastructure/diff/engine');
 
 phutil_require_module('phutil', 'future');
-phutil_require_module('phutil', 'future/exec');
 phutil_require_module('phutil', 'utils');
 
 

--- a/src/applications/diffusion/query/filecontent/svn/DiffusionSvnFileContentQuery.php
+++ b/src/applications/diffusion/query/filecontent/svn/DiffusionSvnFileContentQuery.php
@@ -33,11 +33,11 @@ final class DiffusionSvnFileContentQuery extends DiffusionFileContentQuery {
     $path = $drequest->getPath();
     $commit = $drequest->getCommit();
 
-    $remote_uri = $repository->getDetail('remote-uri');
+    $remote_uri = $repository->getRemoteURI();
 
     try {
-      list($corpus) = execx(
-        'svn --non-interactive %s %s%s@%s',
+      list($corpus) = $repository->execxRemoteCommand(
+        '%s %s%s@%s',
         $this->getNeedsBlame() ? 'blame' : 'cat',
         $remote_uri,
         $path,

--- a/src/applications/diffusion/query/filecontent/svn/__init__.php
+++ b/src/applications/diffusion/query/filecontent/svn/__init__.php
@@ -9,7 +9,6 @@
 phutil_require_module('phabricator', 'applications/diffusion/data/filecontent');
 phutil_require_module('phabricator', 'applications/diffusion/query/filecontent/base');
 
-phutil_require_module('phutil', 'future/exec');
 phutil_require_module('phutil', 'utils');
 
 

--- a/src/applications/repository/daemon/commitdiscovery/svn/PhabricatorRepositorySvnCommitDiscoveryDaemon.php
+++ b/src/applications/repository/daemon/commitdiscovery/svn/PhabricatorRepositorySvnCommitDiscoveryDaemon.php
@@ -28,9 +28,9 @@ class PhabricatorRepositorySvnCommitDiscoveryDaemon
     }
 
     $uri = $this->getBaseSVNLogURI();
-    list($xml) = execx(
-      'svn log --xml --non-interactive --quiet --limit 1 %s@HEAD',
-      $uri);
+    list($xml) = $repository->execxRemoteCommand(
+        ' log --xml --quiet --limit 1 %s@HEAD',
+        $uri);
 
     $results = $this->parseSVNLogXML($xml);
     $commit = key($results);
@@ -47,6 +47,7 @@ class PhabricatorRepositorySvnCommitDiscoveryDaemon
 
   private function discoverCommit($commit, $epoch) {
     $uri = $this->getBaseSVNLogURI();
+    $repository = $this->getRepository();
 
     $discover = array(
       $commit => $epoch,
@@ -58,8 +59,8 @@ class PhabricatorRepositorySvnCommitDiscoveryDaemon
       // Find all the unknown commits on this path. Note that we permit
       // importing an SVN subdirectory rather than the entire repository, so
       // commits may be nonsequential.
-      list($err, $xml, $stderr) = exec_manual(
-        'svn log --xml --non-interactive --quiet --limit %d %s@%d',
+      list($err, $xml, $stderr) = $repository->execRemoteCommand(
+        ' log --xml --quiet --limit %d %s@%d',
         $limit,
         $uri,
         $upper_bound - 1);

--- a/src/applications/repository/daemon/commitdiscovery/svn/__init__.php
+++ b/src/applications/repository/daemon/commitdiscovery/svn/__init__.php
@@ -9,7 +9,6 @@
 phutil_require_module('phabricator', 'applications/repository/constants/repositorytype');
 phutil_require_module('phabricator', 'applications/repository/daemon/commitdiscovery/base');
 
-phutil_require_module('phutil', 'future/exec');
 phutil_require_module('phutil', 'utils');
 
 

--- a/src/applications/repository/storage/repository/PhabricatorRepository.php
+++ b/src/applications/repository/storage/repository/PhabricatorRepository.php
@@ -97,6 +97,12 @@ class PhabricatorRepository extends PhabricatorRepositoryDAO {
     return call_user_func_array('execx', $args);
   }
 
+  public function getRemoteCommandFuture($pattern /*, $arg, ... */) {
+    $args = func_get_args();
+    $args = $this->formatRemoteCommand($args);
+    return newv('ExecFuture', $args);
+  }
+
   public function passthruRemoteCommand($pattern /*, $arg, ... */) {
     $args = func_get_args();
     $args = $this->formatRemoteCommand($args);
@@ -115,11 +121,18 @@ class PhabricatorRepository extends PhabricatorRepositoryDAO {
     return call_user_func_array('execx', $args);
   }
 
+  public function getLocalCommandFuture($pattern /*, $arg, ... */) {
+    $args = func_get_args();
+    $args = $this->formatLocalCommand($args);
+    return newv('ExecFuture', $args);
+
+  }
   public function passthruLocalCommand($pattern /*, $arg, ... */) {
     $args = func_get_args();
     $args = $this->formatLocalCommand($args);
     return call_user_func_array('phutil_passthru', $args);
   }
+
 
   private function formatRemoteCommand(array $args) {
     $pattern = $args[0];

--- a/src/applications/repository/worker/base/PhabricatorRepositoryCommitParserWorker.php
+++ b/src/applications/repository/worker/base/PhabricatorRepositoryCommitParserWorker.php
@@ -68,8 +68,8 @@ abstract class PhabricatorRepositoryCommitParserWorker
     }
 
     try {
-      list($xml) = execx(
-        "svn log --xml {$verbose} --limit 1 --non-interactive %s@%d",
+      list($xml) = $this->repository->execxRemoteCommand(
+        "log --xml {$verbose} --limit 1 %s@%d",
         $uri,
         $revision);
     } catch (CommandException $ex) {

--- a/src/applications/repository/worker/commitchangeparser/svn/PhabricatorRepositorySvnCommitChangeParserWorker.php
+++ b/src/applications/repository/worker/commitchangeparser/svn/PhabricatorRepositorySvnCommitChangeParserWorker.php
@@ -593,10 +593,9 @@ class PhabricatorRepositorySvnCommitChangeParserWorker
     // position in the document.
     $all_paths = array_reverse(array_keys($parents));
     foreach (array_chunk($all_paths, 64) as $path_chunk) {
-      list($raw_xml) = execx(
-        'svn --non-interactive --xml ls %C',
-        implode(' ', $path_chunk));
-
+      list($raw_xml) = $repository->execxRemoteCommand(
+         '--xml ls %C',
+         implode(' ', $path_chunk));
       $xml = new SimpleXMLElement($raw_xml);
       foreach ($xml->list as $list) {
         $list_path = (string)$list['path'];
@@ -669,8 +668,8 @@ class PhabricatorRepositorySvnCommitChangeParserWorker
     $cache_loc = sys_get_temp_dir().'/diffusion.'.$hashkey.'.svnls';
     if (!Filesystem::pathExists($cache_loc)) {
       $tmp = new TempFile();
-      execx(
-        'svn --non-interactive --xml ls -R %s%s@%d > %s',
+      $repository->execxRemoteCommand(
+        '--xml ls -R %s%s@%d > %s',
         $repository->getDetail('remote-uri'),
         $path,
         $rev,


### PR DESCRIPTION
- Added getRemoteCommandFuture(..) and getLocalCommand Future(..) methods to PhabricatorRepository
- Removed irrelevant csprintf(..)
- Updated code to use $repository->getRemoteURI()
- Updated code to use getRemoteCommandFuture(..) in Diffusion code
- Updated code to use $repository->getRemoteURI()
