### PR TITLE
D975

### DIFF
--- a/scripts/daemon/phabricator_daemon_launcher.php
+++ b/scripts/daemon/phabricator_daemon_launcher.php
@@ -45,7 +45,8 @@ switch (isset($argv[1]) ? $argv[1] : 'help') {
     exit($err);
 
   case 'stop':
-    $err = $control->executeStopCommand();
+    $pass_argv = array_slice($argv, 2);
+    $err = $control->executeStopCommand($pass_argv);
     exit($err);
 
   case 'repository-launch-readonly':


### PR DESCRIPTION
Stop 'stop' from being in phd's list twice, and provide a way to kill one particular PID.

Summary:
This is a pretty bad, but working implmentation of a way to kill one particular PID that
is controlled by Phabricator. Also remove the second 'stop' from the ##phd help## list.

Test Plan:
  [ricky@rhelpad01 phabricator](phd-stop-twice)$ ./bin/phd status
  PID   Started                     Daemon
  30154 Oct 1 2011, 2:38:08 AM      PhabricatorMetaMTADaemon
  30172 Oct 1 2011, 2:38:09 AM      PhabricatorMetaMTADaemon
  30190 Oct 1 2011, 2:38:09 AM      PhabricatorMetaMTADaemon
  30210 Oct 1 2011, 2:38:09 AM      PhabricatorMetaMTADaemon

  [ricky@rhelpad01 phabricator](phd-stop-twice)$ ./bin/phd stop 30190
  Stopping daemon 'PhabricatorMetaMTADaemon' (30190)...
  Daemon 30190 exited normally.

  [ricky@rhelpad01 phabricator](phd-stop-twice)$ ./bin/phd stop 123456
  123456 is not controlled by Phabricator. Not killing.

  [ricky@rhelpad01 phabricator](phd-stop-twice)$ ./bin/phd stop
  Stopping daemon 'PhabricatorMetaMTADaemon' (30154)...
  Stopping daemon 'PhabricatorMetaMTADaemon' (30172)...
  Stopping daemon 'PhabricatorMetaMTADaemon' (30210)...
  Daemon 30210 exited normally.
  Daemon 30154 exited normally.
  Daemon 30172 exited normally.

Reviewers: epriestley

CC:

Differential Revision: 975
