### PR TITLE
Better support for installing on Ubuntu.

### DIFF
--- a/scripts/install/install_ubuntu.sh
+++ b/scripts/install/install_ubuntu.sh
@@ -5,6 +5,8 @@ confirm() {
   read -e ignored
 }
 
+GIT='git'
+
 ISSUE=`cat /etc/issue`
 if [[ $ISSUE != Ubuntu* ]]
 then
@@ -12,6 +14,9 @@ then
   echo "to be something else. Your results may vary.";
   echo
   confirm
+elif [[ $ISSUE != "Ubuntu 10.04*" ]]
+then
+  GIT='git-core'
 fi
 
 echo "PHABRICATOR UBUNTU INSTALL SCRIPT";
@@ -37,7 +42,7 @@ echo
 set +x
 
 sudo apt-get -qq update
-sudo apt-get install git mysql-server apache2 php5 php5-mysql php5-gd php5-dev php5-curl php-apc php5-cli dpkg-dev
+sudo apt-get install $GIT mysql-server apache2 php5 php5-mysql php5-gd php5-dev php5-curl php-apc php5-cli dpkg-dev
 
 HAVEPCNTL=`php -r "echo extension_loaded('pcntl');"`
 if [ $HAVEPCNTL != "1" ]


### PR DESCRIPTION
php5-cli should be install before running php on the command line.

git-core provides the command 'git' on Ubuntu LTS.
