### PR TITLE
If id field is not there, do not attempt to key array on it

### DIFF
--- a/src/storage/lisk/dao/LiskDAO.php
+++ b/src/storage/lisk/dao/LiskDAO.php
@@ -593,7 +593,7 @@ abstract class LiskDAO {
 
     foreach ($rows as $row) {
       $obj = clone $this;
-      if ($id_key) {
+      if ($id_key && isset($row[$id_key])) {
         $result[$row[$id_key]] = $obj->loadFromArray($row);
       } else {
         $result[] = $obj->loadFromArray($row);


### PR DESCRIPTION
When LiskDAO object does not use phid as a primary key, getIDKey assumes the key to be 'id'. That causes a problem with records such as PhabricatorSearchDocumentRelationship that have no 'id' field at all (it has phid but it is not unique.) When 'id' field is not there at all, loadAllFromArray a non-existent array element as a key for all records in the final array, basically leaving only one there.
