### PR TITLE
use IN BOOLEAN MODE if boolean mode operators detected

### DIFF
--- a/src/applications/search/engine/mysql/PhabricatorSearchEngineMySQL.php
+++ b/src/applications/search/engine/mysql/PhabricatorSearchEngineMySQL.php
@@ -175,13 +175,23 @@ final class PhabricatorSearchEngineMySQL extends PhabricatorSearchEngine {
     $q = $query->getQuery();
 
     if (strlen($q)) {
-     $join[] = qsprintf(
-        $conn_r,
-        "{$t_field} field ON field.phid = document.phid");
-      $where[] = qsprintf(
-        $conn_r,
-        'MATCH(corpus) AGAINST (%s)',
-        $q);
+      if (preg_match('/[+\-"<>()*~]/', $q)) {
+        $join[] = qsprintf(
+          $conn_r,
+          "{$t_field} field ON field.phid = document.phid");
+        $where[] = str_replace('\\"', '"', qsprintf(
+            $conn_r,
+            'MATCH(corpus) AGAINST (%s IN BOOLEAN MODE)',
+            $q));
+      } else {
+        $join[] = qsprintf(
+          $conn_r,
+          "{$t_field} field ON field.phid = document.phid");
+        $where[] = qsprintf(
+          $conn_r,
+          'MATCH(corpus) AGAINST (%s)',
+          $q);
+      }
 
       // When searching for a string, promote user listings above other
       // listings.


### PR DESCRIPTION
MySQL full-text search runs in "natural language" mode by default, making it hard to search for code, and making it ignore commonly used words such as "function" that may be very relevant in phabricator.

Boolean mode full-test search is more effective in some of those cases, and this patch makes phabricator use boolean mode when it detects boolean mode operators in the search query:

http://dev.mysql.com/doc/refman/5.0/en/fulltext-boolean.html

This enables a search for exact phrases using double quotes, it does not ignore words used in majority of the documents, etc. Since full-text search in natural language mode ignores such special characters anyway, this change should not "break" existing uses - though results will be different in some cases.

The "order by" section below unchanged. Changing the MATCH part there to boolean mode would not make much sense since boolean searches do not order by relevance. Leaving it as-is should be fine in most cases.
