### PR TITLE
Pull request for differential revision D1014

### DIFF
--- a/resources/sql/patches/010.herald.sql
+++ b/resources/sql/patches/010.herald.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE phabricator_herald;
+CREATE DATABASE IF NOT EXISTS phabricator_herald;
 
 CREATE TABLE phabricator_herald.herald_action (
   id int unsigned not null auto_increment primary key,

--- a/resources/sql/patches/018.owners.sql
+++ b/resources/sql/patches/018.owners.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE phabricator_owners;
+CREATE DATABASE IF NOT EXISTS phabricator_owners;
 
 CREATE TABLE phabricator_owners.owners_package (
   id int unsigned not null auto_increment primary key,

--- a/resources/sql/patches/021.xhpastview.sql
+++ b/resources/sql/patches/021.xhpastview.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE phabricator_xhpastview;
+CREATE DATABASE IF NOT EXISTS phabricator_xhpastview;
 CREATE TABLE phabricator_xhpastview.xhpastview_parsetree (
   id int unsigned not null auto_increment primary key,
   authorPHID varchar(64) binary,

--- a/resources/sql/patches/043.pastebin.sql
+++ b/resources/sql/patches/043.pastebin.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE phabricator_pastebin;
+CREATE DATABASE IF NOT EXISTS phabricator_pastebin;
 
 CREATE TABLE phabricator_pastebin.pastebin_paste (
   id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/resources/sql/patches/044.countdown.sql
+++ b/resources/sql/patches/044.countdown.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE phabricator_countdown;
+CREATE DATABASE IF NOT EXISTS phabricator_countdown;
 
 CREATE TABLE phabricator_countdown.countdown_timer (
   id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/resources/sql/patches/053.feed.sql
+++ b/resources/sql/patches/053.feed.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE phabricator_feed;
+CREATE DATABASE IF NOT EXISTS phabricator_feed;
 
 CREATE TABLE phabricator_feed.feed_storydata (
   id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/resources/sql/patches/056.slowvote.sql
+++ b/resources/sql/patches/056.slowvote.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE phabricator_slowvote;
+CREATE DATABASE IF NOT EXISTS phabricator_slowvote;
 
 CREATE TABLE phabricator_slowvote.slowvote_poll (
   id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/resources/sql/patches/060.phriction.sql
+++ b/resources/sql/patches/060.phriction.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE phabricator_phriction;
+CREATE DATABASE IF NOT EXISTS phabricator_phriction;
 
 CREATE TABLE phabricator_phriction.phriction_document (
   id INT UNSIGNED NOT NULL,


### PR DESCRIPTION
Summary:
Current scripts make it hard to administer Phabricator instance while not having
direct (priviledged) access to the database.  This change allows scenario where
DB administrator creates the databases for you before you run update_schema
script.

Test Plan:
Create the databases before running the update_schema script - it shouldn't
complain that the databases already exist.

Reviewers: aran, epriestley

Reviewed By: epriestley

CC: aran, epriestley

Differential Revision: 1014
