### PR TITLE
Pull request for differential revision D1021

### DIFF
--- a/src/applications/metamta/storage/mail/PhabricatorMetaMTAMail.php
+++ b/src/applications/metamta/storage/mail/PhabricatorMetaMTAMail.php
@@ -178,10 +178,12 @@ class PhabricatorMetaMTAMail extends PhabricatorMetaMTADAO {
    * @return this
    */
   public function saveAndSend() {
-    $ret = $this->save();
+    $ret = null;
 
     if (PhabricatorEnv::getEnvConfig('metamta.send-immediately')) {
-      $this->sendNow();
+      $ret = $this->sendNow();
+    } else {
+      $ret = $this->save();
     }
 
     return $ret;
@@ -343,8 +345,7 @@ class PhabricatorMetaMTAMail extends PhabricatorMetaMTADAO {
     } catch (Exception $ex) {
       $this->setStatus(self::STATUS_FAIL);
       $this->setMessage($ex->getMessage());
-      $this->save();
-      return;
+      return $this->save();
     }
 
     if ($this->getRetryCount() < $this->getSimulatedFailureCount()) {
@@ -373,7 +374,7 @@ class PhabricatorMetaMTAMail extends PhabricatorMetaMTADAO {
       $this->setStatus(self::STATUS_SENT);
     }
 
-    $this->save();
+    return $this->save();
   }
 
   public static function getReadableStatus($status_code) {


### PR DESCRIPTION
Prevent duplicated emails with send-immedialtely = true and MTA daemon running

Test Plan:
Set 'metamta.send-immediately' to true.  Start up several MTA daemons, without
the patch you'll probably get multiple emails, with the patch you should get
only one.

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, mareksapota, epriestley

Differential Revision: 1021
