### PR TITLE
[@epriestley] Sending pull request for https://secure.phabricator.com/D1108

### DIFF
--- a/src/applications/repository/worker/commitmessageparser/git/PhabricatorRepositoryGitCommitMessageParserWorker.php
+++ b/src/applications/repository/worker/commitmessageparser/git/PhabricatorRepositoryGitCommitMessageParserWorker.php
@@ -26,15 +26,10 @@ class PhabricatorRepositoryGitCommitMessageParserWorker
     // NOTE: %B was introduced somewhat recently in git's history, so pull
     // commit message information with %s and %b instead.
     list($info) = $repository->execxLocalCommand(
-      'log -n 1 --pretty=format:%%e%%x00%%an%%x00%%s%%n%%n%%b %s',
+      "log -n 1 --encoding='UTF-8' --pretty=format:%%an%%x00%%s%%n%%n%%b %s",
       $commit->getCommitIdentifier());
 
-    list($encoding, $author, $message) = explode("\0", $info);
-
-    if ($encoding != "UTF-8") {
-      $author = mb_convert_encoding($author, 'UTF-8', $encoding);
-      $message = mb_convert_encoding($message, 'UTF-8', $encoding);
-    }
+    list($author, $message) = explode("\0", $info);
 
     // Make sure these are valid UTF-8.
     $author = phutil_utf8ize($author);


### PR DESCRIPTION
Summary:
0d5b0f21ad2bc03988b007b017e44d4210ab9645 added string conversion but MBString always needs an argument for endcoding.

It looks like we can get away with doing this in git instead, with the --encoding='UTF-8' flag. Then we should be safe to remove the test for output type, and stay UTF-8 safe.

Test Plan:
Run updaters with change. Verify commits are updated.

Reviewers: epriestley

CC:

Differential Revision: 1108
