### PR TITLE
Fix php binary location from /usr/bin/php to /usr/bin/env php

### DIFF
--- a/scripts/mail/mail_handler.php
+++ b/scripts/mail/mail_handler.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 /*


### PR DESCRIPTION
Summary: by default it was looking for php to be in /usr/bin/php on some systems
this is incorrect. It should be using /usr/bin/env php for calling php with the
correct path.

Test Plan: patch and try to run.

Reviewers: epriestley

Reviewed By: epriestley

CC: svemir, aran, epriestley

Differential Revision: 1136
