### PR TITLE
Hide auxiliary fields that have no value set

### DIFF
--- a/src/applications/conduit/method/differential/getcommitmessage/ConduitAPI_differential_getcommitmessage_Method.php
+++ b/src/applications/conduit/method/differential/getcommitmessage/ConduitAPI_differential_getcommitmessage_Method.php
@@ -107,7 +107,7 @@ class ConduitAPI_differential_getcommitmessage_Method extends ConduitAPIMethod {
     foreach ($aux_fields as $field_key => $field) {
       $value = $field->renderValueForCommitMessage($is_edit);
       $label = $field->renderLabelForCommitMessage();
-      if ($value === null || !strlen($value)) {
+      if (!strlen($value)) {
         if ($field_key === 'title') {
           $commit_message[] = '<<Enter Revision Title>>';
         } else {

--- a/src/applications/differential/view/revisiondetail/DifferentialRevisionDetailView.php
+++ b/src/applications/differential/view/revisiondetail/DifferentialRevisionDetailView.php
@@ -53,7 +53,7 @@ final class DifferentialRevisionDetailView extends AphrontView {
     $rows = array();
     foreach ($this->auxiliaryFields as $field) {
       $value = $field->renderValueForRevisionView();
-      if ($value !== null) {
+      if (strlen($value)) {
         $label = $field->renderLabelForRevisionView();
         $rows[] =
           '<tr>'.

--- a/src/applications/maniphest/controller/taskdetail/ManiphestTaskDetailController.php
+++ b/src/applications/maniphest/controller/taskdetail/ManiphestTaskDetailController.php
@@ -147,7 +147,11 @@ class ManiphestTaskDetailController extends ManiphestController {
           $aux_field->setValue($attribute->getValue());
         }
 
-        $dict[$aux_field->getLabel()] = $aux_field->renderForDetailView();
+        $value = $aux_field->renderForDetailView();
+
+        if (strlen($value)) {
+          $dict[$aux_field->getLabel()] = $value;
+        }
       }
     }
 


### PR DESCRIPTION
This hides empty auxiliary fields (ones which have a null value or an empty string).
