### PR TITLE
D1209

### DIFF
--- a/src/applications/differential/storage/diff/DifferentialDiff.php
+++ b/src/applications/differential/storage/diff/DifferentialDiff.php
@@ -190,6 +190,8 @@ class DifferentialDiff extends DifferentialDAO {
         'type'          => $changeset->getChangeType(),
         'fileType'      => $changeset->getFileType(),
         'commitHash'    => null,
+        'addLines'      => $changeset->getAddLines(),
+        'delLines'      => $changeset->getDelLines(),
         'hunks'         => $hunks,
       );
       $dict['changes'][] = $change;


### PR DESCRIPTION
Summary: Add 'addLines' and 'delLines' properties to differential.getdiff return
dictionary.  These properties are aggregated from the changesets.

Test Plan: Issue a differential.getdiff query via conduit and verify that
'addLines' and 'removeLines' properties are included and accurate

Reviewers: epriestley

Reviewed By: epriestley

CC: epriestley, aran, jonathanhester

Differential Revision: 1209
