### PR TITLE
Adding explicitly set ircbot notifications

### DIFF
--- a/src/infrastructure/daemon/irc/handler/differentialnotification/PhabricatorIRCDifferentialNotificationHandler.php
+++ b/src/infrastructure/daemon/irc/handler/differentialnotification/PhabricatorIRCDifferentialNotificationHandler.php
@@ -30,6 +30,7 @@ class PhabricatorIRCDifferentialNotificationHandler
 
   public function runBackgroundTasks() {
     $iterator = new PhabricatorTimelineIterator('ircdiffx', array('difx'));
+    $show = $this->getConfig('notification.actions');
 
     if (!$this->skippedOldEvents) {
       // Since we only want to post notifications about new events, skip
@@ -44,7 +45,7 @@ class PhabricatorIRCDifferentialNotificationHandler
 
     foreach ($iterator as $event) {
       $data = $event->getData();
-      if (!$data) {
+      if (!$data || ($show !== null && !in_array($data['action'], $show))) {
         continue;
       }
 


### PR DESCRIPTION
Summary:
This adds a new configuration setting:

  "notification.actions" : [
    "commit",
    "abandon",
    "actions"
  ]

if not set, displays all actions, if is set, display only what is set to display

Test Plan: add the notification.actions settings and set accordingly

Reviewers: epriestley, zeeg

CC: aran, epriestley

Differential Revision: https://secure.phabricator.com/D1820
