### PR TITLE
Fix commit parsing in owners tool after bug introduced in 30ae22bfcff71fa3f14e38fd3cd597448df501c3

### DIFF
--- a/src/applications/owners/query/path/PhabricatorOwnerPathQuery.php
+++ b/src/applications/owners/query/path/PhabricatorOwnerPathQuery.php
@@ -22,7 +22,7 @@ final class PhabricatorOwnerPathQuery {
     PhabricatorRepository $repository,
     PhabricatorRepositoryCommit $commit) {
 
-    $drequest = DiffusionRequest::newFromAphrontRequestDictionary(
+    $drequest = DiffusionRequest::newFromDictionary(
       array(
         'repository'  => $repository,
         'commit'      => $commit->getCommitIdentifier(),


### PR DESCRIPTION
Summary:
A bug was introduced in
rP30ae22bfcff71fa3f14e38fd3cd597448df501c3 which caused commits to start
being parsed as if the repository callsign was empty. This caused errors
and problems and much unhappiness. Example error:

  EXCEPTION: (Exception) No such repository ''. at [.../phabricator/src/applications/diffusion/request/base/DiffusionRequest.php:130]

Test Plan: Saw that commit parsing was breaking. Applied fix. Saw that commits parsed again.

Reviewers: epriestley

CC: aran, epriestley

Differential Revision: https://secure.phabricator.com/D1974
