### PR TITLE
Pull request for D2025 (fix phabricator linter regex issue)

### DIFF
--- a/src/infrastructure/lint/linter/javelin/PhabricatorJavelinLinter.php
+++ b/src/infrastructure/lint/linter/javelin/PhabricatorJavelinLinter.php
@@ -216,7 +216,7 @@ final class PhabricatorJavelinLinter extends ArcanistLinter {
     $symbols = explode("\n", trim($symbols));
     foreach ($symbols as $line) {
       $matches = null;
-      if (!preg_match('/^([?+])([^:]*):(\d+)$/', $line, $matches)) {
+      if (!preg_match('/^([?+\*])([^:]*):(\d+)$/', $line, $matches)) {
         throw new Exception(
           "Received malformed output from `javelinsymbols`.");
       }


### PR DESCRIPTION
Summary: D2023 adds a new '*' token to javelinsymbols (indicating that a behavior is 'installed'). This fixes a sanity-check regex in PhabricatorJavelinLinter that validates the output of javelinsymbols so that it is aware of this new token type.

Test Plan:
Patched javelinsymbols.cpp from D2023 to externals/javelin/support/javelinsymbols, build the new javelinsymbols binary, then ran

  arc lint --lintall webroot/rsrc/js/application/core/behavior-drag-and-drop-textarea.js

(before this diff, that throws an error -- after it works with no lint)

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, epriestley

Differential Revision: https://secure.phabricator.com/D2025
