### PR TITLE
Don't require the user to be logged in to give a 404 response.

### DIFF
--- a/src/applications/base/controller/404/Phabricator404Controller.php
+++ b/src/applications/base/controller/404/Phabricator404Controller.php
@@ -18,6 +18,10 @@
 
 final class Phabricator404Controller extends PhabricatorController {
 
+  public function shouldRequireLogin() {
+    return false;
+  }
+
   public function processRequest() {
     return new Aphront404Response();
   }


### PR DESCRIPTION
Boy were we confused why the login screen kept showing up for a
particular url!  We never would have guessed it's because it was a
404...

(Sorry I'm not using phabricator to do this review, but I can't get it working yet...)
