### PR TITLE
Add docs for using lighttpd as the webserver.

### DIFF
--- a/src/docs/configuration/configuration_guide.diviner
+++ b/src/docs/configuration/configuration_guide.diviner
@@ -171,6 +171,36 @@ For nginx, use a configuration like this:
     }
   }
 
+= Webserver: Configuring lighttpd =
+
+For lighttpd, add a section like this to your lighttpd.conf:
+
+  $HTTP["host"] =~ "phabricator(\.example\.com)?" {
+      server.document-root = "/path/to/phabricator/webroot"
+      url.rewrite-once = (
+          "^(/rsrc/.*)$" => "$1",
+          "^(/favicon.ico)$" => "$1",
+          # This simulates QSA ("query string append") mode in apache
+          "^(/[^?]*)\?(.*)" => "/index.php?__path__=$1&$2",
+          "^(/.*)$" => "/index.php?__path__=$1",
+      )
+      setenv.add-environment = (
+         "PHABRICATOR_ENV" => "custom/myconfig",
+      )
+  }
+
+You should also ensure the following modules are listed in your
+server.modules list:
+
+  mod_fastcgi
+  mod_rewrite
+  mod_setenv
+
+Finally, you should run the following commands to enable php support:
+
+  $ sudo apt-get install php5-cgi  # for ubuntu; other distros should be similar
+  $ sudo lighty-enable-mod fastcgi-php
+
 = Setup =
 
 Now, restart your webserver and navigate to whichever subdomain you set up. You

--- a/src/docs/installation_guide.diviner
+++ b/src/docs/installation_guide.diviner
@@ -14,8 +14,9 @@ Phabricator is a LAMP application suite, so you basically need LAMP:
     patches.) Phabricator has active contributors running it on Mac OS X, Amazon
     Linux, Ubuntu, RHEL and CentOS; if you run into issues on other flavors,
     send patches or complaints.
-  - **Apache** (or nginx): You need Apache (or nginx). You might be able to use
-    something else, but you're on your own.
+  - **Apache** (or nginx, or lighttpd): You need Apache (or another
+    tested webserver). You can probably use something else, but you're
+    on your own.
   - **MySQL**: You need MySQL.
   - **PHP**: You need PHP 5.2 or newer.
 


### PR DESCRIPTION
lighttpd could support rules like this, to add efficiency:

```
# Aggressively cache all static files
$HTTP["url"] =~ "\.(jpg|gif|png|css|js|htc)" {
    expire.url = ( "" => "access 1 years" )
}

# Compress files for faster transfer
compress.filetype = (
    "text/plain",
    "text/html",
    "text/javascript",
    "text/css",
    "text/xml"
)

compress.cache-dir = <would need to set to something>?
```

I don't know if that is necessary or useful.  Probably not a good idea
at this point, where the code is changing so rapidly: a 1 year cache
of javascript code could cause trouble.  And i think the default
lighttpd.conf already compresses text/html, text/plain, text/css, and
application/x-javascript by default, so we're ok there (could add
text/javascript and text/xml, I guess).
