### PR TITLE
Separated ldap and password auth

### DIFF
--- a/src/applications/auth/controller/PhabricatorLoginController.php
+++ b/src/applications/auth/controller/PhabricatorLoginController.php
@@ -77,14 +77,14 @@ final class PhabricatorLoginController
 
     $password_auth = PhabricatorEnv::getEnvConfig('auth.password-auth-enabled');
 
-    $forms = array();
+    $username_or_email = $request->getCookie('phusr');
 
+    $forms = array();
 
     $errors = array();
     if ($password_auth) {
       $require_captcha = false;
       $e_captcha = true;
-      $username_or_email = $request->getCookie('phusr');
       if ($request->isFormPost()) {
 
         if (AphrontFormRecaptchaControl::isRecaptchaEnabled()) {
@@ -188,29 +188,30 @@ final class PhabricatorLoginController
   //    $panel->setCreateButton('Register New Account', '/login/register/');
       $forms['Phabricator Login'] = $form;
 
-      $ldap_provider = new PhabricatorLDAPProvider();
-      if ($ldap_provider->isProviderEnabled()) {
-        $ldap_form = new AphrontFormView();
-        $ldap_form
-          ->setUser($request->getUser())
-          ->setAction('/ldap/login/')
-          ->appendChild(
-            id(new AphrontFormTextControl())
-            ->setLabel('LDAP username')
-            ->setName('username')
-            ->setValue($username_or_email))
-          ->appendChild(
-            id(new AphrontFormPasswordControl())
-            ->setLabel('Password')
-            ->setName('password'));
+    }
 
-        $ldap_form
-          ->appendChild(
-            id(new AphrontFormSubmitControl())
-            ->setValue('Login'));
+    $ldap_provider = new PhabricatorLDAPProvider();
+    if ($ldap_provider->isProviderEnabled()) {
+      $ldap_form = new AphrontFormView();
+      $ldap_form
+        ->setUser($request->getUser())
+        ->setAction('/ldap/login/')
+        ->appendChild(
+          id(new AphrontFormTextControl())
+          ->setLabel('LDAP username')
+          ->setName('username')
+          ->setValue($username_or_email))
+        ->appendChild(
+          id(new AphrontFormPasswordControl())
+          ->setLabel('Password')
+          ->setName('password'));
 
-        $forms['LDAP Login'] = $ldap_form;
-      }
+      $ldap_form
+        ->appendChild(
+          id(new AphrontFormSubmitControl())
+          ->setValue('Login'));
+
+      $forms['LDAP Login'] = $ldap_form;
     }
 
     $providers = PhabricatorOAuthProvider::getAllProviders();


### PR DESCRIPTION
As suggested pulled out the `$username_or_email` variable so LDAP auth can be completely separated.
