### PR TITLE
Exception configuration directive fix (php.ini) upload_max_filesize

### DIFF
--- a/src/applications/files/exception/PhabricatorFileUploadException.php
+++ b/src/applications/files/exception/PhabricatorFileUploadException.php
@@ -22,7 +22,7 @@ final class PhabricatorFileUploadException extends Exception {
     $map = array(
       UPLOAD_ERR_INI_SIZE =>
         "Uploaded file is too large: file is larger than the ".
-        "'upload_max_size' setting in php.ini.",
+        "'upload_max_filesize' setting in php.ini.",
       UPLOAD_ERR_FORM_SIZE =>
         "File is too large.",
       UPLOAD_ERR_PARTIAL =>


### PR DESCRIPTION
Today i got exception "Uploaded file is too large", but noticed that configuration directive was missing "file" in it.

http://php.net/manual/en/features.file-upload.errors.php

> UPLOAD_ERR_INI_SIZE
> Value: 1; The uploaded file exceeds the upload_max_filesize directive in php.ini.
