### PR TITLE
Correcting README

### DIFF
--- a/webroot/rsrc/image/custom/README
+++ b/webroot/rsrc/image/custom/README
@@ -1,3 +1,3 @@
-To customize your Phabricator install's appearance, create a 240x80 PNG like
+To customize your Phabricator install's appearance, create a 220x80 PNG like
 the examples in this folder, name it "custom.png" in this folder, and then set
 'phabricator.custom.logo' to a link URI.


### PR DESCRIPTION
Summary: Custom logos are 220px in width - make README consistent

Test Plan: Read it.

Reviewers: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D2954
