### PR TITLE
Add active-directory domain-based ldap authentication support

### DIFF
--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -604,6 +604,10 @@ return array(
   // the array will be joined
   'ldap.real_name_attributes' => array(),
 
+  // A domain name to use when authenticating against Active Directory
+  // (e.g. 'example.com')
+  'ldap.activedirectory_domain' => '',
+
   // The LDAP version
   'ldap.version' => 3,
 


### PR DESCRIPTION
Summary: Add active-directory domain-based ldap authentication support

Test Plan: Tested on a live install against Active Directory on a Windows Server

Reviewers: epriestley

CC: aran, epriestley

Maniphest Tasks: T1496

Differential Revision: https://secure.phabricator.com/D2966
