### PR TITLE
Use exit statuses to communicate result of 'phd status' to tools

### DIFF
--- a/src/infrastructure/daemon/PhabricatorDaemonControl.php
+++ b/src/infrastructure/daemon/PhabricatorDaemonControl.php
@@ -173,7 +173,8 @@ final class PhabricatorDaemonControl {
             List available daemons.
 
         **status**
-            List running daemons.
+            List running daemons. This command will exit with a non-zero exit
+            status if any daemons are not running.
 
         **help**
             Show this help.


### PR DESCRIPTION
'phd status' always exits with zero. This makes it hard to use it within tools such as puppet, which can't "read the screen" to determine what state the system is in without extensive grep/sed/awk programming. I've patched PhabricatorDaemonControl to return distinct exit statuses in three cases:
- exit status 0 if all is well (all daemons running)
- exit status non-zero if any daemons are not running:
  - exit status 1 if all daemons are stopped
  - exit status 2 if any daemons are in DEAD state

I've also stopped 'phd status' from reaping PID files for dead daemons; 'phd stop' and 'phd restart' handle that just fine on their own, and having 'phd status' change behaviour on successive runs makes programmatically invoking it trickier than it should be.
