### PR TITLE
D3004 Add LDAP Referrals Option

### DIFF
--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -655,6 +655,11 @@ return array(
 
   // The LDAP version
   'ldap.version' => 3,
+  
+  // LDAP Referrals Option
+  // Whether referrals should be followed by the client
+  // Should be set to 0 if you use Windows 2003 AD
+  'ldap.referrals' => 1,
 
 // -- Disqus OAuth ---------------------------------------------------------- //
 

--- a/src/applications/auth/ldap/PhabricatorLDAPProvider.php
+++ b/src/applications/auth/ldap/PhabricatorLDAPProvider.php
@@ -49,6 +49,10 @@ final class PhabricatorLDAPProvider {
   public function getLDAPVersion() {
     return PhabricatorEnv::getEnvConfig('ldap.version');
   }
+  
+  public function getLDAPReferrals() {
+    return PhabricatorEnv::getEnvConfig('ldap.referrals');
+  }
 
   public function retrieveUserEmail() {
     return $this->userData['mail'][0];
@@ -97,6 +101,8 @@ final class PhabricatorLDAPProvider {
 
       ldap_set_option($this->connection, LDAP_OPT_PROTOCOL_VERSION,
         $this->getLDAPVersion());
+      ldap_set_option($this->connection, LDAP_OPT_REFERRALS, 
+       $this->getLDAPReferrals());
     }
 
     return $this->connection;


### PR DESCRIPTION
Summary: In order to perform the searches on Windows 2003 Server Active Directory you have to set the LDAP_OPT_REFERRALS option to 0

Test Plan: Test if LDAP works with Windows 2003 AD

Reviewers: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3004
