### PR TITLE
Fix minor typo in "Writing Reviewable Code"

### DIFF
--- a/src/docs/flavortext/writing_reviewable_code.diviner
+++ b/src/docs/flavortext/writing_reviewable_code.diviner
@@ -76,7 +76,7 @@ Phabricator is 35 lines.
 
 = Write Sensible Commit Messages =
 
-There are lots of resources for this on the internet. All of the say pretty much
+There are lots of resources for this on the internet. All of them say pretty much
 the same thing; this one does too.
 
 The single most important thing is: **commit messages should explain //why// you


### PR DESCRIPTION
I feel like I should exhaustively copy-edit all the documentation in the hopes of finding some more typos to justify sending an entire pull-request. But then I'd probably never do it at all.

So, here you go: here's a tyop that I found!
