### PR TITLE
Added compatibility with PHP 5.4+ built-in web server.

### DIFF
--- a/webroot/index.php
+++ b/webroot/index.php
@@ -57,7 +57,8 @@ if (!$env) {
 if (!isset($_REQUEST['__path__'])) {
   if (php_sapi_name() == 'cli-server') {
     // Compatibility with PHP 5.4+ built-in web server.
-    $_REQUEST['__path__'] = parse_url( $_SERVER['REQUEST_URI'] )[ 'path' ];
+    $url = parse_url($_SERVER['REQUEST_URI']);
+    $_REQUEST['__path__'] = $url['path'];
   } else {
     phabricator_fatal_config_error(
       "__path__ is not set. Your rewrite rules are not configured correctly.");


### PR DESCRIPTION
Phabricator requires mod_rewrite rule to emulate "routing"
interface between web server and PHP aplication. Since PHP 5.4 where
is built-in web server that can be invoked with
"PHP -S 127.0.0.1:8000", but since it's very simple it don't have
mod_rewrite functionality. But it have routing functionality if .php
file is given via command-line - so this simple fix allows to
use PHP 5.4+ built-in web server to start Phabricator. Useful for
hacking, developing and testing. Use like this:

"php -S 127.0.0.1:8000 ~/Documents/phabricator/webroot/ ~/Documents/phabricator/webroot/index.php"
