### PR TITLE
D3079

### DIFF
--- a/src/view/form/control/AphrontFormImageControl.php
+++ b/src/view/form/control/AphrontFormImageControl.php
@@ -33,7 +33,7 @@ final class AphrontFormImageControl extends AphrontFormControl {
           'name'  => $this->getName(),
           'class' => 'image',
         )).
-      '<span>-or-</span>'.
+      '<div style="clear: both;">'.
       phutil_render_tag(
         'input',
         array(
@@ -47,7 +47,8 @@ final class AphrontFormImageControl extends AphrontFormControl {
         array(
           'for' => $id,
         ),
-        'Use Default Image');
+        'Use Default Image instead').
+      '</div>';
   }
 
 }


### PR DESCRIPTION
Summary:
The filename field and the checkbox to select the default image were
overlapping in Firefox on Linux on both the Project Edit page and the
Profile Edit page.

Test Plan: Looked at both of the pages and saw that they rendered better.

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3079
