### PR TITLE
D3081

### DIFF
--- a/src/applications/people/controller/PhabricatorPeopleEditController.php
+++ b/src/applications/people/controller/PhabricatorPeopleEditController.php
@@ -179,10 +179,10 @@ final class PhabricatorPeopleEditController
             id(new PhabricatorUserEditor())
               ->setActor($admin)
               ->createNewUser($user, $email);
+          }
 
-            if ($welcome_checked) {
-              $user->sendWelcomeEmail($admin);
-            }
+          if ($welcome_checked) {
+            $user->sendWelcomeEmail($admin);
           }
 
           $response = id(new AphrontRedirectResponse())
@@ -264,6 +264,15 @@ final class PhabricatorPeopleEditController
         id(new AphrontFormStaticControl())
           ->setLabel('Email')
           ->setValue($status));
+
+      $form->appendChild(
+        id(new AphrontFormCheckboxControl())
+        ->addCheckbox(
+          'welcome',
+          1,
+          'Re-send "Welcome to Phabricator" email.',
+          false));
+
     }
 
     $form->appendChild($this->getRoleInstructions());


### PR DESCRIPTION
Add a checkbox to allow administrators to re-send the welcome email to users.

Summary:
See title - This simply adds a checkbox to the "Edit User" page in the
admin view, to allow an administrator to re-send the "Welcome to Phabricator"
email.

Test Plan:
Sent myself another welcome email using the checkbox.
Created a new user using the admin panel, to make sure emails still get
sent for new users.

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, Korvin

Maniphest Tasks: T1524

Differential Revision: https://secure.phabricator.com/D3081
