### PR TITLE
D3091

### DIFF
--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -1246,4 +1246,14 @@ return array(
   // is ready.
   'preview.viewport-meta-tag' => false,
 
+// -- Environment  ---------------------------------------------------------- //
+
+  // Phabricator occasionally shells out to other binaries on the server.
+  // An example of this is the "pygmentize" command, used to syntax-highlight
+  // code written in languages other than PHP. By default, it is assumed that
+  // these binaries are in the $PATH of the user running Phabricator (normally
+  // 'apache', 'httpd', or 'nobody'). Here you can add extra directories to
+  // the $PATH environment variable, for when these binaries are in non-standard
+  // locations.
+  'environment.append-paths' => array(),
 );

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -91,6 +91,14 @@ try {
     date_default_timezone_set($tz);
   }
 
+  // Append any paths to $PATH if we need to.
+  $paths = PhabricatorEnv::getEnvConfig('environment.append-paths');
+  if (!empty($paths)) {
+    $current_env_path = getenv('PATH');
+    $new_env_paths = implode(':', $paths);
+    putenv('PATH='.$current_env_path.':'.$new_env_paths);
+  }
+
   // This is the earliest we can get away with this, we need env config first.
   PhabricatorAccessLog::init();
   $access_log = PhabricatorAccessLog::getLog();


### PR DESCRIPTION
Summary:
In some cases, we shell out to things (like Pygments for syntax highlighting).
However, on cloud servers or shared web servers, those binaries aren't always
installed system-wide.

This patch allows for appending to the environment variable $PATH, to look for
other, non-default places for these binaries.

Test Plan:
- Copied the patch over to a test OpenShift instance and applied it.
- Added the path to my local copy of Pygments (pygmentize wasn't available on the system)
  into the Phabricator config.
- Refreshed a Paste page, and saw colors.

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3091
