### PR TITLE
Fix Browse Repository in diffusion

### DIFF
--- a/src/applications/repository/storage/PhabricatorRepository.php
+++ b/src/applications/repository/storage/PhabricatorRepository.php
@@ -411,7 +411,7 @@ final class PhabricatorRepository extends PhabricatorRepositoryDAO {
    * @task uri
    */
   public function getPublicRemoteURI() {
-    $uri = $this->getURIObject();
+    $uri = $this->getRemoteURIObject();
 
     // Make sure we don't leak anything if this repo is using HTTP Basic Auth
     // with the credentials in the URI or something zany like that.


### PR DESCRIPTION
After this commit: https://github.com/facebook/phabricator/commit/d9296638cdd4ac98882850ed742adbb08856bef2

I started getting this error:

Unhandled Exception ("Exception")
Bad getter call: getURIObject

It turns out that getURIObject just needed to be getRemoteURIObject and then the problem goes away.
