### PR TITLE
D3149: The Log and PID directory should be separable in the config file

### DIFF
--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -1095,7 +1095,10 @@ return array(
 
   // Directory that phd (the Phabricator daemon control script) should use to
   // track running daemons.
-  'phd.pid-directory' => '/var/tmp/phd',
+  'phd.pid-directory' => '/var/tmp/phd/pid',
+
+  // Directory that the Phabricator daemons should use to store the log file
+  'phd.log-directory' => '/var/tmp/phd/log',
 
   // Number of "TaskMaster" daemons that "phd start" should start. You can
   // raise this if you have a task backlog, or explicitly launch more with

--- a/scripts/daemon/phabricator_daemon_launcher.php
+++ b/scripts/daemon/phabricator_daemon_launcher.php
@@ -225,7 +225,7 @@ function will_launch($control, $with_logs = true) {
   echo "Staging launch...\n";
   $control->pingConduit();
   if ($with_logs) {
-    $log_dir = $control->getControlDirectory('log').'/daemons.log';
+    $log_dir = $control->getLOGDirectory().'/daemons.log';
     echo "NOTE: Logs will appear in '{$log_dir}'.\n\n";
   }
 }


### PR DESCRIPTION
Summary: The Log and PID directory should be separable in the config file

Test Plan: Start the daemons, and check if the pid and log files are stored in directories that were specified in the config file.

Reviewers: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3149
