### PR TITLE
Make quickstart.sql apply correctly on older MySQL instances

### DIFF
--- a/resources/sql/quickstart.sql
+++ b/resources/sql/quickstart.sql
@@ -1406,8 +1406,8 @@ CREATE TABLE `user_nametoken` (
 CREATE TABLE `user_oauthinfo` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `userID` int(10) unsigned NOT NULL,
-  `oauthProvider` varchar(255) NOT NULL,
-  `oauthUID` varchar(255) NOT NULL,
+  `oauthProvider` varchar(255) CHARACTER SET latin1 NOT NULL,
+  `oauthUID` varchar(255) CHARACTER SET latin1 NOT NULL,
   `dateCreated` int(10) unsigned NOT NULL,
   `dateModified` int(10) unsigned NOT NULL,
   `accountURI` varchar(255) DEFAULT NULL,


### PR DESCRIPTION
On older MySQL, specifically on the one shipped with RHEL5x (aye, ancient...) this bit fails:

<pre>CREATE TABLE `user_oauthinfo` (
  ....
  `oauthProvider` varchar(255) NOT NULL,
  `oauthUID` varchar(255) NOT NULL,
  ....
  UNIQUE KEY `oauthProvider` (`oauthProvider`,`oauthUID`)</pre>

with the following error:

<pre>[2012-08-15 14:02:35] EXCEPTION: (AphrontQueryException) #1071: Specified key was too long; max key length is 1000 bytes at /var/www/html/ph/libphutil/src/aphront/storage/connection/mysql/AphrontMySQLDatabaseConnectionBase.php:252]</pre>


Since the two fields use UTF8, MySQL thinks they can result in more than 1000 bytes.

I don't think these fields can ever contain non-latin1 characters so this "fix" should not break anything, right?

The other possibilities are: decrease the length of these fields, forget about old MySQL.
