### PR TITLE
Aphlict should respect PATH settings in the config

### DIFF
--- a/support/aphlict/server/aphlict_launcher.php
+++ b/support/aphlict/server/aphlict_launcher.php
@@ -50,6 +50,14 @@ if (posix_getuid() != 0) {
     "privileged ports.");
 }
 
+// Append any paths to $PATH if we need to.
+$paths = PhabricatorEnv::getEnvConfig('environment.append-paths');
+if (!empty($paths)) {
+  $current_env_path = getenv('PATH');
+  $new_env_paths = implode(':', $paths);
+  putenv('PATH='.$current_env_path.':'.$new_env_paths);
+}
+
 list($err) = exec_manual('node -v');
 if ($err) {
   throw new Exception(


### PR DESCRIPTION
Otherwise it's not possible to install e.g. node.js to non-system directories.

Yes you can set path in your startup scripts as an environment variable but since Phabricator already provides a nice and clean way of appending directories to path, it would make sense to keep things consistent. It's natural to expect all tools in the bundle to respect same generic settings isn't it.
