### PR TITLE
D3410: Fix irc server login 

### DIFF
--- a/src/infrastructure/daemon/irc/PhabricatorIRCBot.php
+++ b/src/infrastructure/daemon/irc/PhabricatorIRCBot.php
@@ -117,10 +117,6 @@ final class PhabricatorIRCBot extends PhabricatorDaemon {
       $this->writeCommand('PASS', "{$pass}");
     }
 
-    if ($nickpass) {
-      $this->writeCommand("NickServ IDENTIFY ", "{$nickpass}");
-    }
-
     $this->writeCommand('NICK', "{$nick}");
     $this->runSelectLoop();
   }

--- a/src/infrastructure/daemon/irc/handler/PhabricatorIRCProtocolHandler.php
+++ b/src/infrastructure/daemon/irc/handler/PhabricatorIRCProtocolHandler.php
@@ -27,6 +27,10 @@ final class PhabricatorIRCProtocolHandler extends PhabricatorIRCHandler {
     switch ($message->getCommand()) {
       case '422': // Error - no MOTD
       case '376': // End of MOTD
+        $nickpass = $this->getConfig('nickpass');
+        if ($nickpass) {
+          $this->write('PRIVMSG', "nickserv :IDENTIFY {$nickpass}");
+        }
         $join = $this->getConfig('join');
         if (!$join) {
           throw new Exception("Not configured to join any channels!");


### PR DESCRIPTION
Summary: Previously, the identification string was thrown at the server long before you were connected, I've moved this to the end of the motd raw, and now errthangz gud

Test Plan: Register an account for your bot to use, give your bot the correct nick and password, then watch

Reviewers: epriestley

CC: aran

Differential Revision: https://secure.phabricator.com/D3410
