### PR TITLE
Git couldn't find the 'current directory' repository on Openshift

### DIFF
--- a/src/applications/repository/storage/PhabricatorRepository.php
+++ b/src/applications/repository/storage/PhabricatorRepository.php
@@ -146,7 +146,7 @@ final class PhabricatorRepository extends PhabricatorRepositoryDAO {
             'csprintf',
             array_merge(
               array(
-                "(ssh-add %s && git {$pattern})",
+                "(ssh-add %s && unset GIT_DIR && git {$pattern})",
                 $this->getSSHKeyfile(),
               ),
               $args));
@@ -235,7 +235,7 @@ final class PhabricatorRepository extends PhabricatorRepositoryDAO {
         array_unshift($args, $this->getLocalPath());
         break;
       case PhabricatorRepositoryType::REPOSITORY_TYPE_GIT:
-        $pattern = "(cd %s && git {$pattern})";
+        $pattern = "(cd %s && unset GIT_DIR && git {$pattern})";
         array_unshift($args, $this->getLocalPath());
         break;
       case PhabricatorRepositoryType::REPOSITORY_TYPE_MERCURIAL:

--- a/src/infrastructure/PhabricatorSetup.php
+++ b/src/infrastructure/PhabricatorSetup.php
@@ -260,7 +260,7 @@ final class PhabricatorSetup {
       self::write(" skip  Not a git clone.\n\n");
     } else {
       list($info) = execx(
-        '(cd %s && git submodule status)',
+        '(cd %s && unset GIT_DIR && git submodule status)',
         $root);
       foreach (explode("\n", rtrim($info)) as $line) {
         $matches = null;
@@ -283,7 +283,7 @@ final class PhabricatorSetup {
             self::write(
               "Setup failure! Git submodule '{$module}' is not up to date. ".
               "Run:\n\n".
-              "  cd {$root} && git submodule update --init\n\n".
+              "  cd {$root} && unset GIT_DIR && git submodule update --init\n\n".
               "...to update submodules.");
             return;
           case ' ':


### PR DESCRIPTION
I'm trying to set a Phabricator instance up on Openshift (using https://github.com/CodeBlock/phabricator-openshift-quickstart as a base) and I was having an evil time getting the git repo to work:

> Command '(cd '/var/lib/stickshift/f58cbc6fcec7441d9d5bf11d49425d13/app-root/data/repos/feedbacker/' && git log --skip=0 -n 15 --pretty=format:'%H:%P' 'origin/master' -- )' failed with error`#128:`
> 
> stdout:
> stderr:
> fatal: Not a git repository: '.'

I made the changes mentioned in the commit message, and now it works.  I checked it on another (Ubuntu) install, and it doesn't seem to have any negative effect.
