### PR TITLE
Add D and reST to default highlighters.

### DIFF
--- a/conf/default.conf.php
+++ b/conf/default.conf.php
@@ -1215,6 +1215,7 @@ return array(
     'c' => 'C',
     'cpp' => 'C++',
     'css' => 'CSS',
+    'd' => 'D',
     'diff' => 'Diff',
     'django' => 'Django Templating',
     'erb' => 'Embedded Ruby/ERB',
@@ -1227,6 +1228,7 @@ return array(
     'objc' => 'Objective-C',
     'perl' => 'Perl',
     'php' => 'PHP',
+    'rest' => 'reStructuredText'
     'text' => 'Plain Text',
     'python' => 'Python',
     'rainbow' => 'Rainbow',


### PR DESCRIPTION
This adds highlighting for the D programming language and the reStructuredText markup language to the default highlighters list.
