### PR TITLE
"Unknown method `PhabricatorEdgeEditor::setUser()`" error fix

### DIFF
--- a/src/applications/maniphest/controller/ManiphestTaskEditController.php
+++ b/src/applications/maniphest/controller/ManiphestTaskEditController.php
@@ -250,7 +250,7 @@ final class ManiphestTaskEditController extends ManiphestController {
 
         if ($parent_task) {
           id(new PhabricatorEdgeEditor())
-            ->setUser($user)
+            ->setActor($user)
             ->addEdge(
               $parent_task->getPHID(),
               PhabricatorEdgeConfig::TYPE_TASK_DEPENDS_ON_TASK,


### PR DESCRIPTION
Fixes "Unknown method `PhabricatorEdgeEditor::setUser()`" error when creating a subtask.

To reproduce a bug:
1. create a task & assign user;
2. create a subtask & assign user.

Seems that somewhere along the way `PhabricatorEdgeEditor::setUser()` was moved out to `PhabricatorEditor` and renamed to `setActor()`. I am not sure if there are other places it is left unchanged, but here is fix to one of more visible actions in Maniphest.

P.S. I have digitally signed Facebook Developer/Contributor agreement (some time ago though :calendar:)
