### PR TITLE
Fix 'View Full Commit History' link

### DIFF
--- a/src/applications/diffusion/controller/DiffusionRepositoryController.php
+++ b/src/applications/diffusion/controller/DiffusionRepositoryController.php
@@ -62,7 +62,10 @@ final class DiffusionRepositoryController extends DiffusionController {
     $all = phutil_render_tag(
       'a',
       array(
-        'href' => "/diffusion/{$callsign}/history/",
+        'href' => $drequest->generateURI(
+          array(
+            'action' => 'history',
+          )),
       ),
       'View Full Commit History');
 


### PR DESCRIPTION
Fix 'View Full Commit History' link to link to the history for the current branch rather than the default branch
