### PR TITLE
Fix call to undefined method for DifferentialChangesetParser::originalRight()

### DIFF
--- a/src/applications/differential/parser/DifferentialChangesetParser.php
+++ b/src/applications/differential/parser/DifferentialChangesetParser.php
@@ -1140,7 +1140,7 @@ final class DifferentialChangesetParser {
         return $output;
     }
 
-    if ($this->originalLeft && $this->originalRight()) {
+    if ($this->originalLeft && $this->originalRight) {
       list($highlight_old, $highlight_new) = $this->diffOriginals();
       $highlight_old = array_flip($highlight_old);
       $highlight_new = array_flip($highlight_new);


### PR DESCRIPTION
OMG!

It's a bit bug.
