### PR TITLE
Fix tokenizer placeholder issue

### DIFF
--- a/src/view/form/control/AphrontFormTokenizerControl.php
+++ b/src/view/form/control/AphrontFormTokenizerControl.php
@@ -41,9 +41,8 @@ final class AphrontFormTokenizerControl extends AphrontFormControl {
       $id = celerity_generate_unique_node_id();
     }
 
-    $placeholder = null;
     if (!$this->placeholder) {
-      $placeholder = $this->getDefaultPlaceholder();
+      $this->placeholder = $this->getDefaultPlaceholder();
     }
 
     $template = new AphrontTokenizerTemplateView();
@@ -64,7 +63,7 @@ final class AphrontFormTokenizerControl extends AphrontFormControl {
         'limit'       => $this->limit,
         'ondemand'    => PhabricatorEnv::getEnvConfig('tokenizer.ondemand'),
         'username'    => $username,
-        'placeholder' => $placeholder,
+        'placeholder' => $this->placeholder,
       ));
     }
 


### PR DESCRIPTION
Summary:
The placeholder property remains null despite it is set to a custom
value.

Test Plan:
Use a custom placeholder in `AphrontFormTokenizerControl`

```
id(new AphrontFormTokenizerControl())
  ->setPlaceholder('My custom placeholder...')
  ->setDatasource('/typeahead/common/projects/');
```

The placeholder should be set to "My custom placeholder..."

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D4297
