### PR TITLE
escape svn repository file paths.

### DIFF
--- a/src/applications/diffusion/query/diff/DiffusionSvnDiffQuery.php
+++ b/src/applications/diffusion/query/diff/DiffusionSvnDiffQuery.php
@@ -140,7 +140,7 @@ final class DiffusionSvnDiffQuery extends DiffusionDiffQuery {
     return $repository->getRemoteCommandFuture(
       'cat %s%s@%d',
       $repository->getRemoteURI(),
-      $ref,
+      phutil_escape_uri($ref),
       $rev);
   }
 

--- a/src/applications/diffusion/query/filecontent/DiffusionSvnFileContentQuery.php
+++ b/src/applications/diffusion/query/filecontent/DiffusionSvnFileContentQuery.php
@@ -16,7 +16,7 @@ final class DiffusionSvnFileContentQuery extends DiffusionFileContentQuery {
         '%C %s%s@%s',
         $this->getNeedsBlame() ? 'blame --force' : 'cat',
         $remote_uri,
-        $path,
+        phutil_escape_uri($path),
         $commit);
     } catch (CommandException $ex) {
       $stderr = $ex->getStdErr();


### PR DESCRIPTION
fix problem when svn repository path contains double-byte characters.
