### PR TITLE
Fix git browsequery on directories.

### DIFF
--- a/src/applications/diffusion/conduit/ConduitAPI_diffusion_browsequery_Method.php
+++ b/src/applications/diffusion/conduit/ConduitAPI_diffusion_browsequery_Method.php
@@ -118,7 +118,7 @@ final class ConduitAPI_diffusion_browsequery_Method
     $commit = $request->getValue('commit');
     $result = $this->getEmptyResultSet();
     if ($commit === null) {
-      $commit = 'HEAD';
+      $commit = 'origin/master';
     }
 
     if ($path == '') {


### PR DESCRIPTION
At the moment you can't add a directory to a package in owners if you're using git. This is because the cat-file command issued performing a browsequery without $commit is only valid for blobs, so trees are always assumed to have been deleted.

This fix defaults to HEAD as the $commit if none is provided.
