### PR TITLE
Wrong argument order when calling DiffusionQuery::callConduitWithDiffusionRequest.

### DIFF
--- a/src/applications/herald/adapter/HeraldCommitAdapter.php
+++ b/src/applications/herald/adapter/HeraldCommitAdapter.php
@@ -114,8 +114,8 @@ final class HeraldCommitAdapter extends HeraldObjectAdapter {
       ));
 
     $raw = DiffusionQuery::callConduitWithDiffusionRequest(
-      $drequest,
       PhabricatorUser::getOmnipotentUser(),
+      $drequest,
       'diffusion.rawdiffquery',
       array(
         'commit' => $this->commit->getCommitIdentifier(),


### PR DESCRIPTION
Due to the exception thrown by callConduitWithDiffusionRequest ("Argument 1 passed to DiffusionQuery::callConduitWithDiffusionRequest() must be an instance of PhabricatorUser, instance of DiffusionGitRequest given, called in /opt/phabricator/phabricator/src/applications/herald/adapter/HeraldCommitAdapter.php on line 123...") the "Field: Any changed file content" in the transcript always contained '<<< Failed to load diff, this may mean the change was unimaginably enormous. >>>'.
