### PR TITLE
Add the quick shortcut to create an image macro. Maybe.

### DIFF
--- a/src/applications/macro/application/PhabricatorApplicationMacro.php
+++ b/src/applications/macro/application/PhabricatorApplicationMacro.php
@@ -21,6 +21,10 @@ final class PhabricatorApplicationMacro extends PhabricatorApplication {
   public function getApplicationGroup() {
     return self::GROUP_UTILITIES;
   }
+  
+  public function getQuickCreateURI() {
+    return $this->getBaseURI().'create/';
+  }
 
   public function getRoutes() {
     return array(


### PR DESCRIPTION
I don't actually have Phabricator installed locally so I have no idea if this works, but in theory this should add one of the + buttons in the left sidebar to quickly add a new macro.
