### PR TITLE
Create 'Add Task' link on project/view page

### DIFF
--- a/src/applications/maniphest/event/ManiphestPeopleMenuEventListener.php
+++ b/src/applications/maniphest/event/ManiphestPeopleMenuEventListener.php
@@ -29,6 +29,11 @@ final class ManiphestPeopleMenuEventListener extends PhutilEventListener {
     } else if ($object instanceof PhabricatorProject) {
       $href = '/maniphest/view/all/?projects='.$object->getPHID();
       $actions[] = $action->setHref($href);
+
+      $actions[] = id(new PhabricatorActionView())
+        ->setName(pht("Add Task"))
+        ->setIcon('create')
+        ->setHref('/maniphest/task/create/?projects=' . $object->getPHID());
     }
 
     $event->setValue('actions', $actions);


### PR DESCRIPTION
Found the workflow a bit strange to add a task to a project, so I added a link to do so directly on the project/view/:id page.
![screen shot 2013-07-26 at 2 38 20 pm](https://f.cloud.github.com/assets/354842/865500/b7302992-f63b-11e2-814d-b8a8edfb4160.png)
