### PR TITLE
Darken BG color for unread notifications

### DIFF
--- a/webroot/rsrc/css/application/base/notification-menu.css
+++ b/webroot/rsrc/css/application/base/notification-menu.css
@@ -59,7 +59,7 @@
 
 .phabricator-notification-list .phabricator-notification-unread,
 .phabricator-notification-menu .phabricator-notification-unread {
-  background: #eceff5;
+  background: #a6d2ea;
   border-color: #e3e8f0;
 }
 


### PR DESCRIPTION
The background color for /notifications/ doesn't contrast enough to
clearly distinguish the unread from the read easily.

I'm not particularly tied to this color, it just looked OK to me.

New: ![2013-10-11-140510_46x11_scrot](https://f.cloud.github.com/assets/947843/1318294/d686f280-32b8-11e3-932d-ee404a47a8c0.png)
Old: ![2013-10-11-140519_52x14_scrot](https://f.cloud.github.com/assets/947843/1318295/d69eaf6a-32b8-11e3-95ce-4753f8c59f4b.png)
