### PR TITLE
Call to a member function attachRepository() on a non-object in DiffusionRequest.php

### DIFF
--- a/src/applications/diffusion/request/DiffusionRequest.php
+++ b/src/applications/diffusion/request/DiffusionRequest.php
@@ -277,8 +277,12 @@ abstract class DiffusionRequest {
         'repositoryID = %d AND commitIdentifier = %s',
         $repository->getID(),
         $this->getCommit());
-      $commit->attachRepository($repository);
-      $this->repositoryCommit = $commit;
+      if (!$commit) {
+        return null;
+      } else {
+        $commit->attachRepository($repository);
+        $this->repositoryCommit = $commit;
+      }
     }
     return $this->repositoryCommit;
   }


### PR DESCRIPTION
When a new repository is added and daemons haven't finished parsing all commits user can face an exception page  trying to open single commit details page (in example: `/rPH796db9f9c650b6342f0b814ed0f756543de783fd`)

```
>>> UNRECOVERABLE FATAL ERROR <<<

Call to a member function attachRepository() on a non-object

/home/bartek/phabricator/phabricator/src/applications/diffusion/request/DiffusionRequest.php:280


┻━┻ ︵ ¯\_(ツ)_/¯ ︵ ┻━┻
```

I've added checking whether SQL query returned commit data.
