### PR TITLE
Make send-as-user more robust.

### DIFF
--- a/src/applications/metamta/adapter/PhabricatorMailImplementationPHPMailerLiteAdapter.php
+++ b/src/applications/metamta/adapter/PhabricatorMailImplementationPHPMailerLiteAdapter.php
@@ -31,6 +31,11 @@ class PhabricatorMailImplementationPHPMailerLiteAdapter
     return $this;
   }
 
+  public function setSender($sender) {
+    $this->mailer->Sender = $sender;
+    $this->mailer->AddCustomHeader('List-Id:' . $sender);
+  }
+
   public function addReplyTo($email, $name = '') {
     $this->mailer->AddReplyTo($email, $name);
     return $this;

--- a/src/applications/metamta/storage/PhabricatorMetaMTAMail.php
+++ b/src/applications/metamta/storage/PhabricatorMetaMTAMail.php
@@ -394,7 +394,8 @@ final class PhabricatorMetaMTAMail extends PhabricatorMetaMTADAO {
               PhabricatorEnv::getEnvConfig('metamta.can-send-as-user');
 
             if ($can_send_as_user) {
-              $mailer->setFrom($actor_email);
+              $mailer->setFrom($actor_email, $actor_name);
+              $mailer->setSender($default_from);
             } else {
               $from_email = coalesce($actor_email, $default_from);
               $from_name = coalesce($actor_name, pht('Phabricator'));


### PR DESCRIPTION
Add a List-Id field when sending as a user. Spam filters assume that something
is not a mailing list if it doesn't set the List-Id header, so we need to set
it when we pretend to be a mailing list.
Also, set the correct user name when sending as a user.
