### PR TITLE
Use accounts typeahead endpoint for project membership

### DIFF
--- a/src/applications/project/controller/PhabricatorProjectMembersEditController.php
+++ b/src/applications/project/controller/PhabricatorProjectMembersEditController.php
@@ -92,7 +92,7 @@ final class PhabricatorProjectMembersEditController
         id(new AphrontFormTokenizerControl())
           ->setName('phids')
           ->setLabel(pht('Add Members'))
-          ->setDatasource('/typeahead/common/users/'))
+          ->setDatasource('/typeahead/common/accounts/'))
       ->appendChild(
         id(new AphrontFormSubmitControl())
           ->addCancelButton('/project/view/'.$project->getID().'/')


### PR DESCRIPTION
This change allows assigning system agents to projects, which helps simplify policy management.
