### PR TITLE
fixing usage message

### DIFF
--- a/src/applications/differential/controller/DifferentialDiffCreateController.php
+++ b/src/applications/differential/controller/DifferentialDiffCreateController.php
@@ -65,7 +65,7 @@ final class DifferentialDiffCreateController extends DifferentialController {
           $arcanist_link,
           phutil_tag('tt', array(), 'svn diff'),
           phutil_tag('tt', array(), 'git diff'),
-          phutil_tag('tt', array(), 'hg diff -g')))
+          phutil_tag('tt', array(), 'hg diff --git')))
       ->appendChild(
         id(new AphrontFormTextAreaControl())
           ->setLabel(pht('Raw Diff'))


### PR DESCRIPTION
phabricator doesn't accept raw hg diff, fixing usage message to specify using git extended diff
