### PR TITLE
Fix InvalidArgumentException PHUIFormPageView::pageErrors

### DIFF
--- a/src/view/form/PHUIFormPageView.php
+++ b/src/view/form/PHUIFormPageView.php
@@ -13,7 +13,7 @@ class PHUIFormPageView extends AphrontView {
   private $isValid;
   private $validateFormPageCallback;
   private $adjustFormPageCallback;
-  private $pageErrors;
+  private $pageErrors = array();
   private $pageName;
 
 


### PR DESCRIPTION
Argument 1 passed to PHUIObjectBoxView::setFormErrors() must be of the type array, not null.

```
2014/01/12 09:26:57 [error] 799#0: *111 FastCGI sent in stderr: "PHP message: [2014-01-12 09:26:57] EXCEPTION: (InvalidArgumentException) Argument 1 passed to PHUIObjectBoxView::setFormErrors() must be of the type array, null given, called in /home/www/phabricator/phabricator/src/view/form/PHUIPagedFormView.php on line 266 and defined at [/home/www/phabricator/libphutil/src/error/PhutilErrorHandler.php:201]
PHP message:   #0 PhutilErrorHandler::handleError(4096, Argument 1 passed to PHUIObjectBoxView::setFormErrors() must be of the type array, null given, called in /home/www/phabricator/phabricator/src/view/form/PHUIPagedFormView.php on line 266 and defined, /home/www/phabricator/phabricator/src/view/phui/PHUIObjectBoxView.php, 69, Array { this => Object PHUIObjectBoxView }) called at [/home/www/phabricator/phabricator/src/view/phui/PHUIObjectBoxView.php:69]
PHP message:   #1 PHUIObjectBoxView::setFormErrors(null) called at [/home/www/phabricator/phabricator/src/view/form/PHUIPagedFormView.php:266]
PHP message:   #2 PHUIPagedFormView::getTagContent() called at [/home/www/phabricator/phabricator/src/view/AphrontTagView.php:156]
PHP message:   #3 AphrontTagView::render() called at [/home/www/phabricator/phabricator/src/view/AphrontView.php:159]
PHP message:   #4 AphrontView::producePhutilSafeHTML() called at [/home/www/phabricator/libphutil/src/markup/render.php:85]
PHP message:   #5 phutil_escape_html(Object PHUIPagedFormView) called at [/home/www/phabricator/libphutil/src/markup/render.php:107]
PHP message:   #6 phutil_escape_html(Array of size 2 starting with: { 0 => Object PhabricatorCrumbsView }) called at [/home/www/phabricator/libphutil/src/markup/render.php:107]
PHP message:   #7 phutil_escape_html(Array { 0 => Array of size 2 starting with: { 0 => Object PhabricatorCrumbsView } }) called at [/home/www/phabricator/libphutil/src/markup/render.php:107]
PHP message:   #8 phutil_escape_html(Array of size 2 starting with: { 0 => null }) called at [/home/www/phabricator/libphutil/src/markup/render.php:65]
```
