### PR TITLE
Fix tab indentation missing in Diffusion

### DIFF
--- a/src/applications/diffusion/controller/DiffusionBrowseFileController.php
+++ b/src/applications/diffusion/controller/DiffusionBrowseFileController.php
@@ -774,7 +774,7 @@ final class DiffusionBrowseFileController extends DiffusionBrowseController {
           "\xE2\x80\x8B",
 
           // TODO: [HTML] Not ideal.
-          phutil_safe_html($line['data']),
+          phutil_safe_html(str_replace("\t", '    ', $line['data'])),
         ));
 
       $rows[] = phutil_tag(


### PR DESCRIPTION
This seems to be a specific of how browsers are dealing with
spaces/tabs. Multiple spaces works just fine, but multiple
tabs were treating as a single space which breaks indentation.

Now made it so tabs are replaced with 4 spaces. Not ideal but
still better than fully unreadable code. This also matches to
how differential is handling tabs.
