### PR TITLE
(PhabricatorIRCProtocolAdapter.connect) Use recommended connection regis...

### DIFF
--- a/src/infrastructure/daemon/bot/adapter/PhabricatorIRCProtocolAdapter.php
+++ b/src/infrastructure/daemon/bot/adapter/PhabricatorIRCProtocolAdapter.php
@@ -49,11 +49,11 @@ final class PhabricatorIRCProtocolAdapter
     }
 
     $this->socket = $socket;
-    $this->write("USER {$user} 0 * :{$user}");
     if ($pass) {
       $this->write("PASS {$pass}");
     }
     $this->write("NICK {$nick}");
+    $this->write("USER {$user} 0 * :{$user}");
   }
 
   public function getNextMessages($poll_frequency) {


### PR DESCRIPTION
...tration order from RFC{1459,2812}

http://tools.ietf.org/html/rfc1459.html#section-4.1 and http://tools.ietf.org/html/rfc2812#section-3.1
 mentions that client should send the PASS first, then the latter of NICK/USER.

This is tested and confirmed working with ngircd commit 485d0aec813db9966922f17aae044df2d82b0b67
