### PR TITLE
Increment copyright year in NOTICE and add 2018 dates to calendar import...

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Phabricator
-Copyright 2013 Facebook, Inc.
+Copyright 2014 Facebook, Inc.
 
 This product includes software developed at
 Facebook, Inc. (http://www.facebook.com/facebook).

--- a/scripts/calendar/import_us_holidays.php
+++ b/scripts/calendar/import_us_holidays.php
@@ -46,6 +46,16 @@ $holidays = array(
   '2017-11-10' => "Veterans Day",
   '2017-11-23' => "Thanksgiving Day",
   '2017-12-25' => "Christmas Day",
+  '2018-01-01' => "New Year's Day",
+  '2018-01-15' => "Birthday of Martin Luther King, Jr.",
+  '2018-02-19' => "Washington's Birthday",
+  '2018-05-28' => "Memorial Day",
+  '2018-07-04' => "Independence Day",
+  '2018-09-03' => "Labor Day",
+  '2018-10-08' => "Columbus Day",
+  '2018-11-12' => "Veterans Day",
+  '2018-11-22' => "Thanksgiving Day",
+  '2018-12-25' => "Christmas Day",
 );
 
 $table = new PhabricatorCalendarHoliday();


### PR DESCRIPTION
Changed copyright year in NOTICE to 2014 and added new dates for 2018 federal holidays to import_us_holidays calendar import script. 

Notes for 2018 year:
Washington's Birthday
This holiday is designated as "Washington’s Birthday" in section 6103(a) of title 5 of the United States Code, which is the law that specifies holidays for Federal employees. Though other institutions such as state and local governments and private businesses may use other names, it is our policy to always refer to holidays by the names designated in the law.

Veterans Day
November 11, 2018 (the legal public holiday for Veterans Day), falls on a Sunday. For most Federal employees, Monday, November 12, will be treated as a holiday for pay and leave purposes. (See section 3(a) of Executive order 11582, February 11, 1971.)

source: http://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/federal-holidays/#url=2018
