### PR TITLE
added options to make realname, email, and username noneditable

### DIFF
--- a/src/applications/auth/controller/PhabricatorAuthRegisterController.php
+++ b/src/applications/auth/controller/PhabricatorAuthRegisterController.php
@@ -99,13 +99,20 @@ final class PhabricatorAuthRegisterController
       }
     }
 
+    $canEditUsername = PhabricatorEnv::getEnvConfig(
+                                         'account.editable-username');
+    $canEditRealname = PhabricatorEnv::getEnvConfig(
+                                         'account.editable-realname');
+    $canEditEmail = PhabricatorEnv::getEnvConfig(
+                                      'account.editable-email');
+
     $profile = id(new PhabricatorRegistrationProfile())
       ->setDefaultUsername($default_username)
       ->setDefaultEmail($default_email)
       ->setDefaultRealName($default_realname)
-      ->setCanEditUsername(true)
-      ->setCanEditEmail(($default_email === null))
-      ->setCanEditRealName(true)
+      ->setCanEditUsername($canEditUsername)
+      ->setCanEditEmail(($default_email === null) || $canEditEmail)
+      ->setCanEditRealName($canEditRealname)
       ->setShouldVerifyEmail(false);
 
     $event_type = PhabricatorEventType::TYPE_AUTH_WILLREGISTERUSER;
@@ -381,6 +388,12 @@ final class PhabricatorAuthRegisterController
           ->setValue($value_email)
           ->setCaption(PhabricatorUserEmail::describeAllowedAddresses())
           ->setError($e_email));
+    } else {
+      $form->appendChild(
+        id(new AphrontFormMarkupControl())
+          ->setLabel(pht('Email'))
+          ->setValue($value_email)
+          ->setError($e_email));
     }
 
     if ($can_edit_realname) {
@@ -388,6 +401,12 @@ final class PhabricatorAuthRegisterController
         id(new AphrontFormTextControl())
           ->setLabel(pht('Real Name'))
           ->setName('realName')
+          ->setValue($value_realname)
+          ->setError($e_realname));
+    } else {
+      $form->appendChild(
+        id(new AphrontFormMarkupControl())
+          ->setLabel(pht('Real name'))
           ->setValue($value_realname)
           ->setError($e_realname));
     }

--- a/src/applications/config/option/PhabricatorAuthenticationConfigOptions.php
+++ b/src/applications/config/option/PhabricatorAuthenticationConfigOptions.php
@@ -90,6 +90,48 @@ final class PhabricatorAuthenticationConfigOptions
             "synchronize account information from some other authoritative ".
             "system, you can disable this to ensure information remains ".
             "consistent across both systems.")),
+      $this->newOption('account.editable-username', 'bool', true)
+        ->setBoolOptions(
+          array(
+            pht("Allow editing"),
+            pht("Prevent editing")
+          ))
+        ->setSummary(
+          pht(
+            "Determines whether or not account username irnformation is ".
+            "editable."))
+        ->setDescription(
+          pht(
+            "Is account username editable? This can be overridden by ".
+            "account.editable")),
+      $this->newOption('account.editable-realname', 'bool', true)
+        ->setBoolOptions(
+          array(
+            pht("Allow editing"),
+            pht("Prevent editing")
+          ))
+        ->setSummary(
+          pht(
+            "Determines whether or not account realname irnformation is ".
+            "editable."))
+        ->setDescription(
+          pht(
+            "Is account realname editable? This can be overridden by ".
+            "account.editable")),
+      $this->newOption('account.editable-email', 'bool', true)
+        ->setBoolOptions(
+          array(
+            pht("Allow editing"),
+            pht("Prevent editing")
+          ))
+        ->setSummary(
+          pht(
+            "Determines whether or not account email irnformation is ".
+            "editable."))
+        ->setDescription(
+          pht(
+            "Is account email editable? This can be overridden by ".
+            "account.editable")),
       $this->newOption('account.minimum-password-length', 'int', 8)
         ->setSummary(pht("Minimum password length."))
         ->setDescription(


### PR DESCRIPTION
We needed to have the ability to make realname and username non-editable, while leaving email editable. I figured that having any of these be editable would be beneficial to others so I have added these options with default configs that won't change phabricator behavior.
