### PR TITLE
Fix commit parsing in non-UTF-8 repositories

### DIFF
--- a/src/applications/repository/worker/commitmessageparser/PhabricatorRepositoryCommitMessageParserWorker.php
+++ b/src/applications/repository/worker/commitmessageparser/PhabricatorRepositoryCommitMessageParserWorker.php
@@ -241,7 +241,9 @@ abstract class PhabricatorRepositoryCommitMessageParserWorker
 
     // TODO: Support adds, deletes and moves under SVN.
     if (strlen($raw_diff)) {
-      $changes = id(new ArcanistDiffParser())->parseDiff($raw_diff);
+      $changes = id(new ArcanistDiffParser())->setDetectBinaryFiles(true)
+        ->setTryEncoding($this->repository->getDetail('encoding', 'UTF-8'))
+        ->parseDiff($raw_diff);
     } else {
       // This is an empty diff, maybe made with `git commit --allow-empty`.
       // NOTE: These diffs have the same tree hash as their ancestors, so


### PR DESCRIPTION
PhabricatorRepositoryCommitMessageParserWorker::generateFinalDiff
enables re-encoding of non-UTF-8 source files in ArcanistDiffParser
(that is needed to pass SQL query validation introduced in D8315)
