### PR TITLE
Fix the stop-on-redirect debug mode

### DIFF
--- a/src/aphront/response/AphrontRedirectResponse.php
+++ b/src/aphront/response/AphrontRedirectResponse.php
@@ -41,10 +41,19 @@ class AphrontRedirectResponse extends AphrontResponse {
 
   public function buildResponseString() {
     if ($this->shouldStopForDebugging()) {
-      $user = new PhabricatorUser();
+      $request = $this->getRequest();
+      if ($request) {
+        $user = $request->getUser();
+      }
+      if (!isset($user)) {
+        $user = new PhabricatorUser();
+        // This fake user needs to be able to generate a CSRF token.
+        $session_key = Filesystem::readRandomCharacters(40);
+        $user->attachAlternateCSRFString(PhabricatorHash::digest($session_key));
+      }
 
       $view = new PhabricatorStandardPageView();
-      $view->setRequest($this->getRequest());
+      $view->setRequest($request);
       $view->setApplicationName('Debug');
       $view->setTitle('Stopped on Redirect');
 


### PR DESCRIPTION
When using that mode, the rendering of the "stop" page was failing in
the generation of CSRF tokens, because it was using a fake
PhabricatorUser not properly set up.

It will now try to reuse the current user, and otherwise properly set
up the PhabricatorUser.
