### PR TITLE
Update function name to follow naming convention.

### DIFF
--- a/src/applications/herald/adapter/HeraldAdapter.php
+++ b/src/applications/herald/adapter/HeraldAdapter.php
@@ -1041,7 +1041,7 @@ abstract class HeraldAdapter {
         break;
       case HeraldPreCommitRefAdapter::FIELD_REF_CHANGE:
         $change_map =
-          PhabricatorRepositoryPushLog::getHeraldChangeflagConditionOptions();
+          PhabricatorRepositoryPushLog::getHeraldChangeFlagConditionOptions();
         foreach ($value as $index => $val) {
           $name = idx($change_map, $val);
           if ($name) {

--- a/src/applications/herald/controller/HeraldRuleController.php
+++ b/src/applications/herald/controller/HeraldRuleController.php
@@ -464,7 +464,7 @@ final class HeraldRuleController extends HeraldController {
     }
 
     $changeflag_options =
-      PhabricatorRepositoryPushLog::getHeraldChangeflagConditionOptions();
+      PhabricatorRepositoryPushLog::getHeraldChangeFlagConditionOptions();
     Javelin::initBehavior(
       'herald-rule-editor',
       array(

--- a/src/applications/repository/storage/PhabricatorRepositoryPushLog.php
+++ b/src/applications/repository/storage/PhabricatorRepositoryPushLog.php
@@ -52,7 +52,7 @@ final class PhabricatorRepositoryPushLog
       ->setPusherPHID($viewer->getPHID());
   }
 
-  public static function getHeraldChangeflagConditionOptions() {
+  public static function getHeraldChangeFlagConditionOptions() {
     return array(
       PhabricatorRepositoryPushLog::CHANGEFLAG_ADD =>
         pht('change creates ref'),


### PR DESCRIPTION
Small function name change to follow the PHP naming convention and be consistent with other Phabricator function names.
