### PR TITLE
D9387: Fix #566: 'PHABRICATOR_USER should be defined' during land to hosted git repo

### DIFF
--- a/src/applications/differential/landing/DifferentialLandingToHostedGit.php
+++ b/src/applications/differential/landing/DifferentialLandingToHostedGit.php
@@ -102,6 +102,7 @@ final class DifferentialLandingToHostedGit
     ArcanistRepositoryAPI $workspace,
     PhabricatorUser $user) {
 
+    putenv('PHABRICATOR_USER=' . $user->getUsername());
     $workspace->execxLocal("push origin HEAD:master");
   }
 


### PR DESCRIPTION
I had the same problem as in #566. Also created https://secure.phabricator.com/D9387.

I am aware that this is probably not the _correct_ way of fixing this, but this hack solves my problem.
