### PR TITLE
If author field is null in commit data, then replace with empty string '...

### DIFF
--- a/src/applications/repository/worker/commitmessageparser/PhabricatorRepositoryCommitMessageParserWorker.php
+++ b/src/applications/repository/worker/commitmessageparser/PhabricatorRepositoryCommitMessageParserWorker.php
@@ -10,6 +10,10 @@ abstract class PhabricatorRepositoryCommitMessageParserWorker
     $committer = $ref->getCommitter();
     $hashes = $ref->getHashes();
 
+    if (!$author) {
+      $author = '';
+    }
+
     $data = id(new PhabricatorRepositoryCommitData())->loadOneWhere(
       'commitID = %d',
       $commit->getID());


### PR DESCRIPTION
Ran into the same issue as mentioned in #617 with an external SVN repository import, so the following is the change I made to deal with the exceptions.
