### PR TITLE
Add backticks around collation to avoid query error

### DIFF
--- a/src/infrastructure/storage/management/PhabricatorStorageManagementAPI.php
+++ b/src/infrastructure/storage/management/PhabricatorStorageManagementAPI.php
@@ -114,7 +114,7 @@ final class PhabricatorStorageManagementAPI {
 
     queryfx(
       $this->getConn(null),
-      'CREATE DATABASE IF NOT EXISTS %T COLLATE %Q',
+      'CREATE DATABASE IF NOT EXISTS %T COLLATE %C',
       $this->getDatabaseName($fragment),
       $collate_text);
   }
@@ -192,8 +192,8 @@ final class PhabricatorStorageManagementAPI {
     foreach ($queries as $query) {
       $query = str_replace('{$NAMESPACE}', $this->namespace, $query);
       $query = str_replace('{$CHARSET}', $charset, $query);
-      $query = str_replace('{$COLLATE_TEXT}', $collate_text, $query);
-      $query = str_replace('{$COLLATE_SORT}', $collate_sort, $query);
+      $query = str_replace('{$COLLATE_TEXT}', '`' . $collate_text . '`', $query);
+      $query = str_replace('{$COLLATE_SORT}', '`' . $collate_sort . '`', $query);
       queryfx(
         $conn,
         '%Q',


### PR DESCRIPTION
Encountered the following when running `./bin/storage upgrade`, with MySQL 5.1.67:

```
[2014-10-05 17:59:48] EXCEPTION: (AphrontQueryException) #1064: You have an error in your SQL
syntax; check  the manual that corresponds to your MySQL server version for the right syntax to
use near 'binary' at line 1 at
[<phutil>/src/aphront/storage/connection/mysql/AphrontBaseMySQLDatabaseConnection.php:308]
```

The offending queries all contained `...COLLATE binary'. Adding backticks around "binary" solves the error and allows the migrations to run.
