### PR TITLE
Fix Conduit project.create breaking with empty members list.

### DIFF
--- a/src/applications/project/conduit/ProjectCreateConduitAPIMethod.php
+++ b/src/applications/project/conduit/ProjectCreateConduitAPIMethod.php
@@ -41,13 +41,15 @@ final class ProjectCreateConduitAPIMethod extends ProjectConduitAPIMethod {
       ->setTransactionType($type_name)
       ->setNewValue($request->getValue('name'));
 
-    $xactions[] = id(new PhabricatorProjectTransaction())
-      ->setTransactionType(PhabricatorTransactions::TYPE_EDGE)
-      ->setMetadataValue('edge:type', PhabricatorEdgeConfig::TYPE_PROJ_MEMBER)
-      ->setNewValue(
-        array(
-          '+' => array_fuse($members),
-        ));
+    if ($members !== null) {
+      $xactions[] = id(new PhabricatorProjectTransaction())
+        ->setTransactionType(PhabricatorTransactions::TYPE_EDGE)
+        ->setMetadataValue('edge:type', PhabricatorEdgeConfig::TYPE_PROJ_MEMBER)
+        ->setNewValue(
+          array(
+            '+' => array_fuse($members),
+          ));
+    }
 
     $editor = id(new PhabricatorProjectTransactionEditor())
       ->setActor($user)


### PR DESCRIPTION
Project.create currently breaks if you omit the optional members argument. A simple null check fixes this.
