### PR TITLE
Allow config to run even if no database present

### DIFF
--- a/src/applications/config/management/PhabricatorConfigManagementGetWorkflow.php
+++ b/src/applications/config/management/PhabricatorConfigManagementGetWorkflow.php
@@ -59,8 +59,8 @@ final class PhabricatorConfigManagementGetWorkflow
       );
     }
 
-    $database_config = new PhabricatorConfigDatabaseSource('default');
     try {
+      $database_config = new PhabricatorConfigDatabaseSource('default');
       $database_value = $database_config->getKeys(array($key));
       if (empty($database_value)) {
         $values['database'] = array(


### PR DESCRIPTION
PhabricatorConfigDatabaseSource throws an exception if it cannot connect
to the database. The config manager should still allow for local changes
to be retrieved even if a database has not been configured yet or is not
functional.
