### PR TITLE
Fixing the PathURI for svn info requests

### DIFF
--- a/src/applications/repository/engine/PhabricatorRepositoryDiscoveryEngine.php
+++ b/src/applications/repository/engine/PhabricatorRepositoryDiscoveryEngine.php
@@ -215,9 +215,14 @@ final class PhabricatorRepositoryDiscoveryEngine
 
 
   private function verifySubversionRoot(PhabricatorRepository $repository) {
-    list($xml) = $repository->execxRemoteCommand(
-      'info --xml %s',
-      $repository->getSubversionPathURI());
+
+    $subversionPathURI = $repository->getSubversionPathURI();
+
+    if (strpos($subversionPathURI, 'svn+ssh') !== false && strpos($subversionPathURI, '@') !== false) {
+      $subversionPathURI .= '@';
+    }
+
+    list($xml) = $repository->execxRemoteCommand('info --xml %s', $subversionPathURI);
 
     $xml = phutil_utf8ize($xml);
     $xml = new SimpleXMLElement($xml);


### PR DESCRIPTION
Added an at sign to the end of the URI if the base URI contains 'svn+ssh' and an at sign

This is a possible fix for https://github.com/phacility/phabricator/issues/788.