### PR TITLE
Correct `notification.pid` to `notification.pidfile`

### DIFF
--- a/src/docs/user/configuration/notifications.diviner
+++ b/src/docs/user/configuration/notifications.diviner
@@ -80,7 +80,7 @@ You may also want to adjust these settings:
   - `notification.server-uri` Internally-facing host and port that Phabricator
     will connect to in order to publish notifications.
   - `notification.log` Log file location for the server.
-  - `notification.pid` Pidfile location used to stop any running server when
+  - `notification.pidfile` Pidfile location used to stop any running server when
     aphlict is restarted.
 
 


### PR DESCRIPTION
The correct conf variable is `notification.pidfile`, not `notification.pid`.
See:
  * [src/applications/config/option/PhabricatorNotificationConfigOptions.php:58](https://github.com/phacility/phabricator/blob/master/src/applications/config/option/PhabricatorNotificationConfigOptions.php#L58)
  * [src/applications/aphlict/management/PhabricatorAphlictManagementWorkflow.php:34](https://github.com/phacility/phabricator/blob/master/src/applications/aphlict/management/PhabricatorAphlictManagementWorkflow.php#L34)