### PR TITLE
Option "ui.custom-css" to override default Phabricator UI styling

### DIFF
--- a/src/applications/config/controller/PhabricatorConfigEditController.php
+++ b/src/applications/config/controller/PhabricatorConfigEditController.php
@@ -270,6 +270,7 @@ final class PhabricatorConfigEditController
           }
           break;
         case 'string':
+        case 'text':
         case 'enum':
           $set_value = (string)$value;
           break;
@@ -360,6 +361,7 @@ final class PhabricatorConfigEditController
       switch ($type) {
         case 'int':
         case 'string':
+        case 'text':
         case 'enum':
         case 'class':
           return $value;
@@ -392,6 +394,11 @@ final class PhabricatorConfigEditController
         case 'int':
         case 'string':
           $control = id(new AphrontFormTextControl());
+          break;
+        case 'text':
+          $control = id(new AphrontFormTextAreaControl())
+            ->setHeight(AphrontFormTextAreaControl::HEIGHT_VERY_TALL)
+            ->setCustomClass('PhabricatorMonospaced');
           break;
         case 'bool':
           $control = id(new AphrontFormSelectControl())

--- a/src/applications/config/option/PhabricatorUIConfigOptions.php
+++ b/src/applications/config/option/PhabricatorUIConfigOptions.php
@@ -50,6 +50,20 @@ EOJSON;
           pht(
             'Sets the color of the main header.'))
         ->setEnumOptions($options),
+      $this->newOption('ui.custom-css', 'text', null)
+        ->setSummary(
+          pht(
+            'Adds CSS rules to customize the Phabricator UI.'))
+        ->setDescription(
+          pht(
+            'Adds CSS rules to customize the Phabricator UI styling. '.
+            'You know, for when you have mad design skillz.'))
+        ->addExample(
+          'body { font-size: 200%; }',
+          pht('Really Big Text'))
+        ->addExample(
+          'textarea { font-family: monospace; }',
+          pht('Monospace Input')),
       $this->newOption('ui.footer-items', 'list<wild>', array())
         ->setSummary(
           pht(

--- a/src/view/page/PhabricatorStandardPageView.php
+++ b/src/view/page/PhabricatorStandardPageView.php
@@ -277,10 +277,12 @@ final class PhabricatorStandardPageView extends PhabricatorBarePageView {
       '.platform-windows .PhabricatorMonospaced, '.
       '.platform-windows .phabricator-remarkup '.
         '.remarkup-code-block .remarkup-code { font: %s; }'.
+      '%s'.
       '</style>%s',
       parent::getHead(),
       phutil_safe_html($monospaced),
       phutil_safe_html($monospaced_win),
+      phutil_safe_html(PhabricatorEnv::getEnvConfigIfExists('ui.custom-css')),
       $response->renderSingleResource('javelin-magical-init', 'phabricator'));
   }
 


### PR DESCRIPTION
this PR allows installations to override the default Phabricator CSS with custom CSS via the "ui.custom-css" configuration option.

since this option is best represented as a multi-line string, this PR also adds the "text" configuration type, which is generally handled like a string, except that it uses a "textarea" HTML element for input.
