### PR TITLE
Better handling of user input on mobile tokenizers

### DIFF
--- a/webroot/rsrc/externals/javelin/lib/control/tokenizer/Tokenizer.js
+++ b/webroot/rsrc/externals/javelin/lib/control/tokenizer/Tokenizer.js
@@ -105,7 +105,7 @@ JX.install('Tokenizer', {
 
       JX.DOM.listen(
         focus,
-        ['click', 'focus', 'blur', 'keydown', 'keypress', 'paste'],
+        ['click', 'focus', 'blur', 'keydown', 'keypress', 'input'],
         null,
         JX.bind(this, this.handleEvent));
 


### PR DESCRIPTION
iOS doesn’t register the new key value into a text input until after the keypress event has fired. This makes the tokenizer one key press behind. The input event is fired whenever the input changes. This list of events also matches Typeahead’s default DOM events for changes.