### PR TITLE
Fix Mercurial unable to authenticate when pulling

### DIFF
--- a/src/applications/repository/engine/PhabricatorRepositoryPullEngine.php
+++ b/src/applications/repository/engine/PhabricatorRepositoryPullEngine.php
@@ -430,7 +430,8 @@ final class PhabricatorRepositoryPullEngine
     $path = $repository->getLocalPath();
 
     // This is a local command, but needs credentials.
-    $future = $repository->getRemoteCommandFuture('pull -u');
+    $remote = $repository->getRemoteURIEnvelope();
+    $future = $repository->getRemoteCommandFuture('pull -u %P', $remote);
     $future->setCWD($path);
 
     try {


### PR DESCRIPTION
In some configuration, Diffusion is unable to update because Mercurial fails to provide the necessary credentials during the pull command.

I understand that HTTP credentials are passed in the modified remote URL (using username:password@host scheme), but when calling hg pull, the remote URL is not given again. Mercurial only stores the username in the remote URL, so to be able to authenticate, we need to give it the full remote URL again.