### PR TITLE
Hardcode some more refs paths

### DIFF
--- a/src/applications/diffusion/query/lowlevel/DiffusionLowLevelGitRefQuery.php
+++ b/src/applications/diffusion/query/lowlevel/DiffusionLowLevelGitRefQuery.php
@@ -31,7 +31,9 @@ final class DiffusionLowLevelGitRefQuery extends DiffusionLowLevelQuery {
 
     if ($this->isOriginBranch) {
       if ($repository->isWorkingCopyBare()) {
+        $prefix = 'refs/changes/';
         $prefix = 'refs/heads/';
+        $prefix = 'refs/meta/';
       } else {
         $remote = DiffusionGitBranch::DEFAULT_GIT_REMOTE;
         $prefix = 'refs/remotes/'.$remote.'/';


### PR DESCRIPTION
Hardcode refs/changes/ and refs/meta/ since phabricator won't replicate those even if a user specify that so hard code it so it does.