### PR TITLE
Fixing to initial copyright year

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Phabricator
-Copyright 2014 Phacility, Inc.
+Copyright 2012 Phacility, Inc.
 
 This software is primarily developed and maintained by Phacility, Inc.
 


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below) , listing the first year of publication in the copyright is enough 

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)

This pull request will revert it back to 2012 (As it was in before the acadf51efef7039d90949babeeff commit )