### PR TITLE
Add missing colon in URI

### DIFF
--- a/src/applications/audit/controller/PhabricatorAuditAddCommentController.php
+++ b/src/applications/audit/controller/PhabricatorAuditAddCommentController.php
@@ -84,7 +84,7 @@ final class PhabricatorAuditAddCommentController
 
     $monogram = $commit->getRepository()->getMonogram();
     $identifier = $commit->getCommitIdentifier();
-    $uri = '/'.$monogram.$identifier;
+    $uri = '/'.$monogram.':'.$identifier;
 
     return id(new AphrontRedirectResponse())->setURI($uri);
   }


### PR DESCRIPTION
redirect to the wrong URI when adding comment.