### PR TITLE
Fix an compatibility issue in install_ubuntu.sh

### DIFF
--- a/scripts/install/install_ubuntu.sh
+++ b/scripts/install/install_ubuntu.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -e
+
 confirm() {
   echo "Press RETURN to continue, or ^C to cancel.";
-  read -e ignored
+  read ignored
 }
 
 GIT='git'


### PR DESCRIPTION
Vanilla Ubuntu 14.04 rejects the `-e` flag on `read`.
Also `set -e` to terminate the script on all errors, which hopefully makes it a bit safer.