### PR TITLE
Fix typo in function calling

### DIFF
--- a/src/applications/config/option/PhabricatorCoreConfigOptions.php
+++ b/src/applications/config/option/PhabricatorCoreConfigOptions.php
@@ -282,10 +282,9 @@ final class PhabricatorCoreConfigOptions
             "Config option '%s' is invalid. The URI must contain a dot ".
             "('%s'), like '%s', not just a bare name like '%s'. Some web ".
             "browsers will not set cookies on domains with no TLD.",
-            '.',
+            $key,
             'http://example.com/',
-            'http://example/',
-            $key));
+            'http://example/'));
       }
 
       $path = $uri->getPath();

--- a/src/applications/config/option/PhabricatorCoreConfigOptions.php
+++ b/src/applications/config/option/PhabricatorCoreConfigOptions.php
@@ -269,10 +269,10 @@ final class PhabricatorCoreConfigOptions
         throw new PhabricatorConfigValidationException(
           pht(
             "Config option '%s' is invalid. The URI must start with ".
-            "%s' or '%s'.",
+            "'%s' or '%s'.",
+            $key,
             'http://',
-            'https://',
-            $key));
+            'https://'));
       }
 
       $domain = $uri->getDomain();


### PR DESCRIPTION
There was a typo with missing single quotes and with the function parameters. This made the message to be printed wrongly.