### PR TITLE
Status Closed should also concieved as Accepted

### DIFF
--- a/src/applications/diffusion/herald/DiffusionPreCommitContentRevisionAcceptedHeraldField.php
+++ b/src/applications/diffusion/herald/DiffusionPreCommitContentRevisionAcceptedHeraldField.php
@@ -21,7 +21,8 @@ final class DiffusionPreCommitContentRevisionAcceptedHeraldField
     }
 
     $status_accepted = ArcanistDifferentialRevisionStatus::ACCEPTED;
-    if ($revision->getStatus() != $status_accepted) {
+    $status_closed = ArcanistDifferentialRevisionStatus::CLOSED;
+    if (($revision->getStatus() != $status_accepted) && ($revision->getStatus() != $status_closed)) {
       return null;
     }
 


### PR DESCRIPTION
This is related to a scenarion in https://secure.phabricator.com/T4754.

- arc feature
- ... do work ...
- arc diff
- (Diff accepted)
- arc land
- (Herald rule checks status == accepted, allows commit)
- (Commit worker detects diff and closes it)
- git checkout lts
- git cherry-pick master
- git push ....
- (Herald rule sees status == closed, rejects push) **(this should be allowed)**