### PR TITLE
Fix RHEL Install script to install gcc on Version 6+ systems.

### DIFF
--- a/scripts/install/install_rhel-derivs.sh
+++ b/scripts/install/install_rhel-derivs.sh
@@ -72,7 +72,7 @@ then
   YUMCOMMAND="$SUDO yum install httpd git php53 php53-cli php53-mysql php53-process php53-devel php53-gd gcc wget make pcre-devel mysql-server"
 else
   # RHEL 6+ defaults with php 5.3
-  YUMCOMMAND="$SUDO yum install httpd git php php-cli php-mysql php-process php-devel php-gd php-pecl-apc php-pecl-json php-mbstring mysql-server"
+  YUMCOMMAND="$SUDO yum install httpd git php php-cli php-mysql php-process php-devel php-gd gcc wget make php-pecl-apc php-pecl-json php-mbstring mysql-server"
 fi
 
 echo "Dropping to yum to install dependencies..."


### PR DESCRIPTION
In example a minimal install of CentOS 7 does not include gcc, the install script does not install this on v6+ systems but did already on v5 systems.