### PR TITLE
Improve password reset message

### DIFF
--- a/src/applications/auth/controller/PhabricatorEmailLoginController.php
+++ b/src/applications/auth/controller/PhabricatorEmailLoginController.php
@@ -94,10 +94,8 @@ final class PhabricatorEmailLoginController
               "Condolences on forgetting your password. You can use this ".
               "link to reset it:\n\n".
               "  %s\n\n".
-              "After you set a new password, consider writing it down on a ".
-              "sticky note and attaching it to your monitor so you don't ".
-              "forget again! Choosing a very short, easy-to-remember password ".
-              "like \"cat\" or \"1234\" might also help.\n\n".
+              "After you set a new password, consider using a password manager ".
+              "to store it so you don't forget again!\n\n".
               "Best Wishes,\nPhabricator\n",
               $uri);
 


### PR DESCRIPTION
The existing password reset message gives terrible advice, in what I think was probably an attempt at sarcasm. Unfortunately sarcasm is often lost on many users and this messaging will at best end up being confusing and create more work for teams that support phabricator.

I'm proposing new default language that keeps the spirit of the original but with better security advice without any sarcasm that could lead to confusion or more work for teams supporting phabricator. 