### PR TITLE
Modified API error message for edit transaction type check

### DIFF
--- a/src/applications/transactions/editengine/PhabricatorEditEngine.php
+++ b/src/applications/transactions/editengine/PhabricatorEditEngine.php
@@ -2103,9 +2103,10 @@ abstract class PhabricatorEditEngine
         throw new Exception(
           pht(
             'Parameter "%s" must contain a list of transaction descriptions, '.
-            'but item with key "%s" is not a dictionary.',
+            'but item with key "%s" is of type "%s".',
             $transactions_key,
-            $key));
+            $key,
+            gettype($xaction)));
       }
 
       if (!array_key_exists('type', $xaction)) {


### PR DESCRIPTION
I once reached this error message and it seemed illogical.
To paraphrase: I need a list, but this is not a dictionary.

I believe this change will remove confusion.