### PR TITLE
phab upgrade broke celerity map

### DIFF
--- a/scripts/setup/manage_celerity.php
+++ b/scripts/setup/manage_celerity.php
@@ -2,7 +2,7 @@
 <?php
 
 $root = dirname(dirname(dirname(__FILE__)));
-require_once $root.'/scripts/__init_script__.php';
+require_once $root.'/scripts/init/init-setup.php';
 
 $args = new PhutilArgumentParser($argv);
 $args->setTagline(pht('manage celerity'));


### PR DESCRIPTION
This phacilitates pre-generating celerity maps without requiring access to a database.