### PR TITLE
Distinguish between deleted and emptied files in diff shield

### DIFF
--- a/src/applications/differential/parser/DifferentialChangesetParser.php
+++ b/src/applications/differential/parser/DifferentialChangesetParser.php
@@ -956,8 +956,13 @@ final class DifferentialChangesetParser extends Phobject {
           pht('This file was changed only by adding or removing whitespace.'),
           'whitespace');
       } else if ($this->isDeleted()) {
-        $shield = $renderer->renderShield(
-          pht('This file was completely deleted.'));
+         if ($this->changeset->getChangeType() == DifferentialChangeType::TYPE_MODIFIED) {
+            $shield = $renderer->renderShield(
+              pht('This file was completely emptied.'));
+        } else {
+            $shield = $renderer->renderShield(
+              pht('This file was completely deleted.'));
+        }
       } else if ($this->changeset->getAffectedLineCount() > 2500) {
         $shield = $renderer->renderShield(
           pht(


### PR DESCRIPTION
The Phabricator UI uses a rendershield over file contents when the content in various contexts, including when the file is empty.  In empty cases, it currently uses the text "This file was completely deleted.", even when the file is still present, but empty.  

This change addresses that issue by checking if the underlying file was deleted (or simply modified), and showing the text "This file was completely emptied." in the edge case.