### PR TITLE
if default_message == !null

### DIFF
--- a/src/applications/people/controller/PhabricatorPeopleWelcomeController.php
+++ b/src/applications/people/controller/PhabricatorPeopleWelcomeController.php
@@ -51,7 +51,7 @@ final class PhabricatorPeopleWelcomeController
     $default_message = PhabricatorAuthMessage::loadMessage(
       $admin,
       PhabricatorAuthWelcomeMailMessageType::MESSAGEKEY);
-    if (strlen($default_message->getMessageText())) {
+    if ($default_message != null && strlen($default_message->getMessageText())) {
       $message_instructions = pht(
         'The email will identify you as the sender. You may optionally '.
         'replace the [[ %s | default custom mail body ]] with different text '.


### PR DESCRIPTION
Per our discussion here: https://discourse.phabricator-community.org/t/call-to-a-member-function-getmessagetext-on-null/2304

this fixes a bug caused by bug from https://secure.phabricator.com/D19995 adding if == !null 

This successfully worked in our local instance. 

