### PR TITLE
Enhancing custom fields of type select to be exported correctly to excel

### DIFF
--- a/src/infrastructure/customfield/standard/PhabricatorStandardCustomFieldSelect.php
+++ b/src/infrastructure/customfield/standard/PhabricatorStandardCustomFieldSelect.php
@@ -152,5 +152,9 @@ final class PhabricatorStandardCustomFieldSelect
     return id(new BulkSelectParameterType())
       ->setOptions($this->getOptions());
   }
+  
+  protected function newExportFieldType() {
+    return new PhabricatorSelectExportField($this);
+  }
 
 }

--- a/src/infrastructure/export/field/PhabricatorSelectExportField.php
+++ b/src/infrastructure/export/field/PhabricatorSelectExportField.php
@@ -1,0 +1,28 @@
+<?php
+
+final class PhabricatorSelectExportField
+  extends PhabricatorExportField {
+
+  private $phabricatorStandardCustomField;
+
+  function __construct($_phabricatorStandardCustomField){
+        $this->phabricatorStandardCustomField = $_phabricatorStandardCustomField;
+  }
+
+  
+
+  public function setPhabricatorStandardCustomField($value){
+      $this->phabricatorStandardCustomField = $value;
+      return $this;
+  }
+
+  public function getPhabricatorStandardCustomField(){
+    return $this->phabricatorStandardCustomField;
+  }
+
+  public function getTextValue($value) {
+    $field =  $this->getPhabricatorStandardCustomField();
+    $field_Options = $field->getOptions();
+    return $field_Options[$value];
+  }
+}


### PR DESCRIPTION
Enhancing Custom fields of type select to be exported as part of excel exports. This allows for exporting human readable values for custom select fields. The feature was lost after refactoring done a year back. Was previously supported through extensions when `Export to Excel` button was available.

Tried adding only an extension but the initialization of the `PhabricatorSelectExportField` needs a reference to the `PhabricatorStandardCustomField` object to get options from the custom select field. :tada: :tada: 🎉 🎉 