### PR TITLE
Fix attached files names in mail_handler.php

### DIFF
--- a/scripts/mail/mail_handler.php
+++ b/scripts/mail/mail_handler.php
@@ -80,7 +80,7 @@ foreach ($parser->getAttachments() as $attachment) {
   $file = PhabricatorFile::newFromFileData(
     $attachment->getContent(),
     array(
-      'name' => $attachment->getFilename(),
+      'name' => phutil_decode_mime_header($attachment->getFilename()),
       'viewPolicy' => PhabricatorPolicies::POLICY_NOONE,
     ));
   $attachments[] = $file->getPHID();


### PR DESCRIPTION
Convert attached files names to human readable format, i.e. "Тест.txt" instead of "=?UTF-8?B?0KLQtdGB0YIudHh0?="