### PR TITLE
Fix "implode()" argument order in query string construction

### DIFF
--- a/src/view/phui/PHUIPropertyListView.php
+++ b/src/view/phui/PHUIPropertyListView.php
@@ -284,7 +284,7 @@ final class PHUIPropertyListView extends AphrontView {
     return phutil_tag(
       'div',
       array(
-        'class' => implode($classes, ' '),
+        'class' => implode(' ', $classes),
       ),
       $part['content']);
   }
@@ -295,7 +295,7 @@ final class PHUIPropertyListView extends AphrontView {
     return phutil_tag(
       'div',
       array(
-        'class' => implode($classes, ' '),
+        'class' => implode(' ', $classes),
       ),
       $part['content']);
   }


### PR DESCRIPTION
Tested in PHP 7.4, fixed the following error when opening a uploaded file:
```
Unhandled Exception ("Exception")	
Error while loading file "/var/www/phabricator/phabricator/src/view/phui/PHUIPropertyListView.php": implode(): Passing glue string after array is deprecated. Swap the parameters
```