### PR TITLE
fixed documentation error

### DIFF
--- a/src/docs/user/field/repository_imports.diviner
+++ b/src/docs/user/field/repository_imports.diviner
@@ -54,7 +54,7 @@ the import process is stuck.
 First, to identify which commits have missing import steps, run this command:
 
 ```
-phabricator/ $ ./bin/repository importing rXYZ
+phabricator/ $ ./bin/repository importing Rxyz
 ```
 
 That will show what work remains to be done. Each line shows a commit which


### PR DESCRIPTION
1. I know you don't accept pull requests. This is the quickest way I figured to report the error.

2. Assuming the reader understands that "XYZ" or "xyz" (whether it's in lower or uppercase) has to be replaced with the repository numeric ID, the R has to be uppercase. Otherwise you'll get an error "repository r123 does not exist". I guess it's best to have xyz be in a different case than the R, to make it more obvious that only xyz is the part to be replaced (just like XYZ was uppercase when the r was wrongly lowercase). I would even consider writing "R123" instead.