### PR TITLE
Use CSS line-break property to allow arbitrary wrapping

### DIFF
--- a/webroot/rsrc/css/core/syntax.css
+++ b/webroot/rsrc/css/core/syntax.css
@@ -12,7 +12,7 @@
 
 .remarkup-code td > span {
   display: inline;
-  word-break: break-all;
+  line-break: anywhere;
 }
 
 .remarkup-code .rbw_r { color: red; }


### PR DESCRIPTION
To enable "terminal-like" line wrapping, where the text wraps at the margin regardless of word boundaries, whitespace, etc., the appropriate CSS property to use is `line-break: anywhere`. The (rather confusingly similar) `word-break: break-all` property only enables breaks *within* words, but does not provide the desired break opportunities at other places such as between a word and an adjacent non-letter symbol.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1637589 for example and explanation.