### PR TITLE
Optimize file object policy checks.

### DIFF
--- a/src/applications/files/query/PhabricatorFileQuery.php
+++ b/src/applications/files/query/PhabricatorFileQuery.php
@@ -183,6 +183,12 @@ final class PhabricatorFileQuery
         $always_visible = true;
       }
 
+      $file_view_policy = $file->getViewPolicy();
+      if ($file_view_policy == PhabricatorPolicies::POLICY_PUBLIC ||
+          $file_view_policy == PhabricatorPolicies::POLICY_USER) {
+        $always_visible = true;
+      }
+
       if ($always_visible) {
         // We just treat these files as though they aren't attached to
         // anything. This saves a query in common cases when we're loading


### PR DESCRIPTION
Skip checking file's view policy if it is public or all_users.

Background: if we are posting updates/comments in CI and attach files/memes to the message. The files will have huge amount of edges. During rendering, the policy check will take a lot of time and resource. For public/all_users files, skipping the checks will save a lot of time and IO.